### PR TITLE
Remove `vade-universal-resolver` from default DID features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ java-lib = ["c-lib"]
 did = [
     "did-substrate",
     "did-sidetree",
-    "did-universal-resolver",
+    # "did-universal-resolver",
     "did-read",
     "did-write",
 ]


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Removes `vade-universal-resolver` from default DID features to avoid getting no DID documents for results, that cannot be resolved via `vade-universal-resolver`.

## Details

<!--- HOW does it change stuff? -->

## Impact on Rollout/Usage

- `vade-universal-resolver` results won't be resolved with default feature set