### PR TITLE
Bump dependency version (vade-sidetree)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,8 +4046,7 @@ dependencies = [
 [[package]]
 name = "vade-sidetree"
 version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb172d99227b406aee4b2aad239ac06b6a4347c53d7ca188e1e36eef6f7cdf7a"
+source = "git+https://github.com/evannetwork/vade-sidetree.git?branch=develop#fb940432c560a987ec0099e02e859be7c7d5acc7"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -4064,8 +4063,7 @@ dependencies = [
 [[package]]
 name = "vade-sidetree-client"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413004bad0d190be624f4339cde70bf3e6724323ee38f275048826e504c3ddc6"
+source = "git+https://github.com/evannetwork/vade-sidetree.git?branch=develop#fb940432c560a987ec0099e02e859be7c7d5acc7"
 dependencies = [
  "base64 0.13.0",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ vade-jwt-vc = { version = "0.2.0", optional = true }
 # feature "did-universal-resolver"
 vade-universal-resolver = { version = "0.0.4", optional = true }
 # feature "did-sidetree"
-vade-sidetree = { version = "0.0.3", optional = true }
+vade-sidetree = { git = "https://github.com/evannetwork/vade-sidetree.git", branch = "develop", version = "0.0.3", optional = true }
 # feature "didcomm"
 vade-didcomm = { version = "0.3.0", optional = true }
 


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Bumps dependency version of vade-sidetree to enable passing keys to `did_create`.