### PR TITLE
Bump dependency version (vade-sidetree)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,7 +3942,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.3.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=sdk#5bd27d91d5852aa911100ca5f5f2ef3d8e249668"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=sdk#9f153796abe1085c46b34c597f9d4aa647769c45"
 dependencies = [
  "async-trait",
  "base64 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4033,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "vade-sidetree"
 version = "0.0.3"
-source = "git+https://github.com/evannetwork/vade-sidetree.git?branch=sdk#642a4c39c04eb0923b47ebe7441b9e7f9c46f785"
+source = "git+https://github.com/evannetwork/vade-sidetree.git?branch=sdk#0585d5c61f267e6f4db9465f50e20d169ab5b0b4"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -4051,7 +4051,7 @@ dependencies = [
 [[package]]
 name = "vade-sidetree-client"
 version = "0.1.0"
-source = "git+https://github.com/evannetwork/vade-sidetree.git?branch=sdk#642a4c39c04eb0923b47ebe7441b9e7f9c46f785"
+source = "git+https://github.com/evannetwork/vade-sidetree.git?branch=sdk#0585d5c61f267e6f4db9465f50e20d169ab5b0b4"
 dependencies = [
  "base64 0.13.0",
  "bitflags",


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Bumps dependency version of vade-sidetree to enable passing keys to `did_create`.

## Details

- bumps dependency version for `vade-sidetree` and for `vade-evan-bbs`, that also relies on it