### PR TITLE
Refactor feature configuraton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3939,7 +3939,6 @@ dependencies = [
  "jni",
  "log",
  "openssl",
- "ring",
  "serde",
  "serde_derive",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ wasm-opt = ["-Oz", "--enable-mutable-globals"]
 [features]
 default = ["bundle-default", "target-cli"]
 
-# plugins we want to enable in our
+# plugins we want to be enabled by default
 bundle-default = [
     "plugin-did-sidetree",
     "plugin-did-substrate",
@@ -37,8 +37,9 @@ bundle-default = [
     "plugin-vc-zkp-bbs",
 ]
 
-# defines a feature named `sdk`, this feature should be enabled when plugin is compiled for IN3 sdk
+# plugins for sdk build, this feature should be enabled when plugin is compiled for IN3 sdk
 bundle-sdk = [
+    "capability-sdk",
     "plugin-did-sidetree",
     "plugin-vc-zkp-bbs",
 ]
@@ -77,6 +78,12 @@ plugin-vc-zkp-bbs = [
     "vade-evan-bbs",
 ]
 
+# enable support for using the `c_lib` module to process requests
+capability-c-lib = [
+    "tokio",
+    "vade-didcomm/portable",
+]
+
 # enable didcomm related functions in targets
 capability-didcomm = []
 
@@ -94,8 +101,7 @@ capability-vc-zkp = []
 
 # build for consuming vade-evan from C
 target-c-lib = [
-    "tokio",
-    "vade-didcomm/portable",
+    "capability-c-lib",
 ]
 
 # build for command line usage
@@ -108,7 +114,7 @@ target-cli = [
 
 # build for consuming vade-evan from Java
 target-java-lib = [
-    "target-c-lib",
+    "capability-c-lib",
 ]
 
 # build for usage in wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,42 +116,67 @@ target-wasm = [
     "vade-evan-bbs/wasm",
 ]
 
+############################################################################### generic dependencies
 [dependencies]
 async-trait = "0.1.31"
 cfg-if = "0.1"
 jni = "0.19.0"
-ring = { version = "0.16.19", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.53", features = ["preserve_order", "raw_value"] }
-vade = "0.1.0"
 thiserror = "1.0.38"
-anyhow = "1.0.68"
+vade = "0.1.0"
 
 ###################################################################### feature specific dependencies
-# feature "plugin-vc-zkp-bbs"
-vade-evan-bbs = { version = "0.3.0", optional = true, default-features = false }
+# plugin-did-sidetree
+[dependencies.vade-sidetree]
+git = "https://github.com/evannetwork/vade-sidetree.git"
+branch = "develop"
+version = "0.0.3"
+optional = true
 
-# feature "target-cli"
-clap = { version = "2.33.1", optional = true }
-tokio = { version = "=1.7.1", optional = true, features = ["rt-multi-thread", "macros"] }
+# plugin-did-substrate
+[dependencies.vade-evan-substrate]
+version = "0.2.0"
+optional = true
 
-# feature "plugin-did-substrate"
-vade-evan-substrate = { version = "0.2.0", optional = true }
-vade-signer = { version = "0.0.1", optional = true }
+# plugin-didcomm
+[dependencies.vade-didcomm]
+version = "0.3.0"
+optional = true
 
-# feature "plugin-jwt-vc"
-vade-jwt-vc = { version = "0.2.0", optional = true }
+# plugin-jwt-vc
+[dependencies.vade-jwt-vc]
+version = "0.2.0"
+optional = true
 
-# feature "plugin-universal-resolver"
-vade-universal-resolver = { version = "0.0.4", optional = true }
+# plugin-signer
+[dependencies.vade-signer]
+version = "0.0.1"
+optional = true
 
-# feature "plugin-did-sidetree"
-vade-sidetree = { git = "https://github.com/evannetwork/vade-sidetree.git", branch = "develop", version = "0.0.3", optional = true }
+# plugin-vc-zkp-bbs
+[dependencies.vade-evan-bbs]
+version = "0.3.0"
+optional = true
+default-features = false
 
-# feature "plugin-didcomm"
-vade-didcomm = { version = "0.3.0", optional = true }
+# plugin-universal-resolver
+[dependencies.vade-universal-resolver]
+version = "0.0.4"
+optional = true
 
-# add openssl dependency for specific targets
+# target-cli
+[dependencies.clap]
+version = "2.33.1"
+optional = true
+
+# target-cli
+[dependencies.tokio]
+version = "=1.7.1"
+optional = true
+features = ["rt-multi-thread", "macros"]
+
+####################################################################### target specific dependencies
 [target.'cfg(any(target_arch = "x86_64-unknown-linux-gnu", target_arch = "x86_64-apple-darwin", target_arch = "aarch64-apple-darwin", target_arch = "x86_64-pc-windows-msvc"))'.dependencies]
 openssl = { version = "*", features = ["vendored"] }
 
@@ -163,12 +188,16 @@ serde_derive = "1.0.114"
 wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.5"
 
+############################################################################ generic dev dependencies
 [dev-dependencies]
+anyhow = "1.0.68"
 tokio = { version = "0.2.22", features = ["macros", "rt-threaded"] }
 
+################################################################### target specific dev dependencies
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.12"
 
+################################################################################# build dependencies
 [build-dependencies]
 serde = "1.0"
 serde_derive = "1.0.114"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,60 +29,25 @@ wasm-opt = ["-Oz", "--enable-mutable-globals"]
 default = ["bundle-default", "target-cli"]
 
 # plugins we want to be enabled by default
-bundle-default = [
-    "plugin-did-sidetree",
-    "plugin-did-substrate",
-    "plugin-didcomm",
-    "plugin-jwt-vc",
-    "plugin-vc-zkp-bbs",
-]
+bundle-default = ["plugin-did-sidetree", "plugin-did-substrate", "plugin-didcomm", "plugin-jwt-vc", "plugin-vc-zkp-bbs"]
 
 # plugins for sdk build, this feature should be enabled when plugin is compiled for IN3 sdk
-bundle-sdk = [
-    "capability-sdk",
-    "plugin-did-sidetree",
-    "plugin-vc-zkp-bbs",
-]
+bundle-sdk = ["capability-sdk", "plugin-did-sidetree", "plugin-vc-zkp-bbs"]
 
-plugin-did-sidetree = [
-    "capability-did-read",
-    "capability-did-write",
-    "vade-sidetree",
-]
+plugin-did-sidetree = ["capability-did-read", "capability-did-write", "vade-sidetree"]
 
-plugin-did-substrate = [
-    "capability-did-read",
-    "capability-did-write",
-    "plugin-signer",
-    "vade-evan-substrate",
-]
+plugin-did-substrate = ["capability-did-read", "capability-did-write", "plugin-signer", "vade-evan-substrate"]
 
-plugin-didcomm = [
-    "capability-didcomm",
-    "vade-didcomm",
-]
+plugin-didcomm = ["capability-didcomm", "vade-didcomm"]
 
-plugin-jwt-vc = [
-    "capability-vc-zkp",
-    "plugin-signer",
-    "vade-jwt-vc",
-]
+plugin-jwt-vc = ["capability-vc-zkp", "plugin-signer", "vade-jwt-vc"]
 
-plugin-signer = [
-    "vade-signer",
-]
+plugin-signer = ["vade-signer"]
 
-plugin-vc-zkp-bbs = [
-    "capability-vc-zkp",
-    "plugin-signer",
-    "vade-evan-bbs",
-]
+plugin-vc-zkp-bbs = ["capability-vc-zkp", "plugin-signer", "vade-evan-bbs"]
 
 # enable support for using the `c_lib` module to process requests
-capability-c-lib = [
-    "tokio",
-    "vade-didcomm/portable",
-]
+capability-c-lib = ["tokio", "vade-didcomm/portable"]
 
 # enable didcomm related functions in targets
 capability-didcomm = []
@@ -100,28 +65,16 @@ capability-sdk = []
 capability-vc-zkp = []
 
 # build for consuming vade-evan from C
-target-c-lib = [
-    "capability-c-lib",
-]
+target-c-lib = ["capability-c-lib"]
 
 # build for command line usage
-target-cli = [
-    "anyhow",
-    "clap",
-    "tokio",
-    "vade-didcomm/portable",
-]
+target-cli = ["anyhow", "clap", "tokio", "vade-didcomm/portable"]
 
 # build for consuming vade-evan from Java
-target-java-lib = [
-    "capability-c-lib",
-]
+target-java-lib = ["capability-c-lib"]
 
 # build for usage in wasm
-target-wasm = [
-    "vade-didcomm/wasm",
-    "vade-evan-bbs/wasm",
-]
+target-wasm = ["vade-didcomm/wasm", "vade-evan-bbs/wasm"]
 
 ############################################################################### generic dependencies
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ target-c-lib = [
 
 # build for command line usage
 target-cli = [
+    "anyhow",
     "clap",
     "tokio",
     "vade-didcomm/portable",
@@ -166,6 +167,10 @@ version = "0.0.4"
 optional = true
 
 # target-cli
+[dependencies.anyhow]
+version = "1.0.68"
+optional = true
+
 [dependencies.clap]
 version = "2.33.1"
 optional = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,6 @@ bundle-sdk = [
     "plugin-vc-zkp-bbs",
 ]
 
-plugin-vade-signer = [
-    "vade-signer",
-]
-
 plugin-did-sidetree = [
     "capability-did-read",
     "capability-did-write",
@@ -56,25 +52,28 @@ plugin-did-sidetree = [
 plugin-did-substrate = [
     "capability-did-read",
     "capability-did-write",
-    "plugin-vade-signer",
+    "plugin-signer",
     "vade-evan-substrate",
 ]
 
 plugin-didcomm = [
     "capability-didcomm",
     "vade-didcomm",
-    "vade-didcomm/portable", # target related, should be moved :/
 ]
 
 plugin-jwt-vc = [
     "capability-vc-zkp",
-    "plugin-vade-signer",
+    "plugin-signer",
     "vade-jwt-vc",
+]
+
+plugin-signer = [
+    "vade-signer",
 ]
 
 plugin-vc-zkp-bbs = [
     "capability-vc-zkp",
-    "plugin-vade-signer",
+    "plugin-signer",
     "vade-evan-bbs",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,108 +20,102 @@ crate-type = ["cdylib", "rlib"]
 [[bin]]
 name = "vade_evan_cli"
 path = "src/main.rs"
-required-features = ["cli"]
+required-features = ["target-cli"]
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
 [features]
-default = ["cli", "did", "didcomm", "portable", "vc-zkp"]
+default = ["bundle-default", "target-cli"]
 
-# add command line interface; not compatible with `wasm` feature
-cli = [
-    "clap",
-    "did",
-    "didcomm",
-    "tokio",
-    "vc-zkp",
-]
-
-# expose C interface for C applications to use vade
-c-lib = [
-    "did",
-    "didcomm",
-    "tokio",
-    "vc-zkp",
-]
-
-# expose Java interface for Java applications to use vade
-java-lib = ["c-lib"]
-
-# enables using DIDs, also required for some vc-zkp functions
-did = [
-    "did-substrate",
-    "did-sidetree",
-    # "did-universal-resolver",
-    "did-read",
-    "did-write",
-]
-
-# enables zkp plugins, required for zkp plugins
-vc-zkp = [
-    "vc-zkp-bbs",
-    "vc-zkp-cl",
-    "vc-jwt",
-]
-
-# dedicated vc handlers
-vc-zkp-bbs = [
-    "vade-signer",
-    "vade-evan-bbs",
-]
-vc-zkp-cl = [
-    "ring",
-    "vade-signer",
-    "vade-evan-cl",
-]
-
-# dummy feature to support vade-evan-cl
-vade-evan-cl = []
-
-# enables did_resolve related functions and commands
-did-read = []
-
-# enables did_create, did_update related functions and commands
-did-write = []
-
-# dedicated did resolvers
-did-sidetree = [
-    "vade-sidetree",
-]
-did-substrate = [
-    "vade-signer",
-    "vade-evan-substrate",
-]
-did-universal-resolver = [
-    "vade-universal-resolver",
-]
-
-# enables didcomm message features
-didcomm = [
-    "vade-didcomm",
-]
-
-# default native setup, vade-evan-cl is disabled currently
-portable = [
-    "vade-didcomm/portable",
-#   "vade-evan-cl/portable",
-]
-
-# enables JWT signature based VC support
-vc-jwt = [
-    "vade-signer",
-    "vade-jwt-vc",
-]
-
-# build to run as wasm file; not compatible with `native` feature, vade-evan-cl is disabled currently
-wasm = [
-    "vade-didcomm/wasm",
-#   "vade-evan-cl/wasm",
-    "vade-evan-bbs/wasm",
+# plugins we want to enable in our
+bundle-default = [
+    "plugin-did-sidetree",
+    "plugin-did-substrate",
+    "plugin-didcomm",
+    "plugin-jwt-vc",
+    "plugin-vc-zkp-bbs",
 ]
 
 # defines a feature named `sdk`, this feature should be enabled when plugin is compiled for IN3 sdk
-sdk = ["vade-universal-resolver/sdk"]
+bundle-sdk = [
+    "plugin-did-sidetree",
+    "plugin-vc-zkp-bbs",
+]
+
+plugin-vade-signer = [
+    "vade-signer",
+]
+
+plugin-did-sidetree = [
+    "capability-did-read",
+    "capability-did-write",
+    "vade-sidetree",
+]
+
+plugin-did-substrate = [
+    "capability-did-read",
+    "capability-did-write",
+    "plugin-vade-signer",
+    "vade-evan-substrate",
+]
+
+plugin-didcomm = [
+    "capability-didcomm",
+    "vade-didcomm",
+    "vade-didcomm/portable", # target related, should be moved :/
+]
+
+plugin-jwt-vc = [
+    "capability-vc-zkp",
+    "plugin-vade-signer",
+    "vade-jwt-vc",
+]
+
+plugin-vc-zkp-bbs = [
+    "capability-vc-zkp",
+    "plugin-vade-signer",
+    "vade-evan-bbs",
+]
+
+# enable didcomm related functions in targets
+capability-didcomm = []
+
+# enable did resolve in targets
+capability-did-read = []
+
+# enable did create and update in targets
+capability-did-write = []
+
+# enable sdk related features
+capability-sdk = []
+
+# enable vc related functiosn in targets
+capability-vc-zkp = []
+
+# build for consuming vade-evan from C
+target-c-lib = [
+    "tokio",
+    "vade-didcomm/portable",
+]
+
+# build for command line usage
+target-cli = [
+    "clap",
+    "tokio",
+    "vade-didcomm/portable",
+]
+
+# build for consuming vade-evan from Java
+target-java-lib = [
+    "target-c-lib",
+]
+
+# build for usage in wasm
+target-wasm = [
+    "vade-didcomm/wasm",
+    "vade-evan-bbs/wasm",
+]
 
 [dependencies]
 async-trait = "0.1.31"
@@ -131,29 +125,32 @@ ring = { version = "0.16.19", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.53", features = ["preserve_order", "raw_value"] }
 vade = "0.1.0"
-###################################################################### feature specific dependencies
-# feature "vc-zkp-bbs"
-vade-evan-bbs = { version = "0.3.0", optional = true, default-features = false }
-
-# feature "vc-zkp-cl", it will be enabled when vade-evan-cl is published to crates.io
-# vade-evan-cl = { git = "https://github.com/evannetwork/vade-evan-cl.git", branch = "develop", version = "0.1.3", default-features = false }
-
-# feature "cli"
-clap = { version = "2.33.1", optional = true }
-tokio = { version = "=1.7.1", optional = true, features = ["rt-multi-thread", "macros"] }
-# feature "did-substrate"
-vade-evan-substrate = { version = "0.2.0", optional = true }
-vade-signer = { version = "0.0.1", optional = true }
-# feature "vc-jwt"
-vade-jwt-vc = { version = "0.2.0", optional = true }
-# feature "did-universal-resolver"
-vade-universal-resolver = { version = "0.0.4", optional = true }
-# feature "did-sidetree"
-vade-sidetree = { git = "https://github.com/evannetwork/vade-sidetree.git", branch = "develop", version = "0.0.3", optional = true }
-# feature "didcomm"
-vade-didcomm = { version = "0.3.0", optional = true }
 thiserror = "1.0.38"
 anyhow = "1.0.68"
+
+###################################################################### feature specific dependencies
+# feature "plugin-vc-zkp-bbs"
+vade-evan-bbs = { version = "0.3.0", optional = true, default-features = false }
+
+# feature "target-cli"
+clap = { version = "2.33.1", optional = true }
+tokio = { version = "=1.7.1", optional = true, features = ["rt-multi-thread", "macros"] }
+
+# feature "plugin-did-substrate"
+vade-evan-substrate = { version = "0.2.0", optional = true }
+vade-signer = { version = "0.0.1", optional = true }
+
+# feature "plugin-jwt-vc"
+vade-jwt-vc = { version = "0.2.0", optional = true }
+
+# feature "plugin-universal-resolver"
+vade-universal-resolver = { version = "0.0.4", optional = true }
+
+# feature "plugin-did-sidetree"
+vade-sidetree = { git = "https://github.com/evannetwork/vade-sidetree.git", branch = "develop", version = "0.0.3", optional = true }
+
+# feature "plugin-didcomm"
+vade-didcomm = { version = "0.3.0", optional = true }
 
 # add openssl dependency for specific targets
 [target.'cfg(any(target_arch = "x86_64-unknown-linux-gnu", target_arch = "x86_64-apple-darwin", target_arch = "aarch64-apple-darwin", target_arch = "x86_64-pc-windows-msvc"))'.dependencies]
@@ -164,7 +161,7 @@ console_error_panic_hook = "0.1.6"
 console_log = { version = "0.2", features = ["color"] }
 log = "0.4.8"
 serde_derive = "1.0.114"
-wasm-bindgen = { version = "0.2",features = ["serde-serialize"] }
+wasm-bindgen = { version = "0.2", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.5"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -98,7 +98,20 @@ yarn && node index.js
 
 This example will generate a new DID, assign a document to it and update it afterwards.
 
-### Features for building
+## Features
+
+### Feature name schema
+
+Features in this project follow a naming schema that looks as following:
+
+- `bundle-` features decide which (`VadePlugin`) plugins to include
+- `target-` features decide which build target (CLI, WASM, etc.) to build for
+- `plugin-` feature take care, that plugins and related dependencies are present
+- `capability-` features control which functionalities a `plugin-` may offer
+
+`bundle-`, `target-` and `plugin-` are intended to be used for build/run commands. `capability-` should only be used from within `Cargo.toml` to allow including functionalities in the source files.
+
+### Feature overview
 
 | feature              | default | contents                             |
 |----------------------|:-------:|--------------------------------------|

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -12,6 +12,8 @@
 
 ### Deprecation
 
+- refactor feature names and combinations
+
 ## v0.4.0
 
 ### Features

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,18 @@ use std::path::Path;
 
 use serde_derive::{Deserialize, Serialize};
 
+macro_rules! append_features {
+    ( $output:ident, $( $feature:expr ),* ) => {
+        {
+            $output.push_str("\n[features]");
+            $(
+                #[cfg(feature = $feature)]
+                $output.push_str(&format!("\n{}", $feature));
+            )*
+        }
+    };
+}
+
 #[derive(Deserialize, Serialize)]
 struct Package {
     name: String,
@@ -39,42 +51,27 @@ fn main() {
     #[allow(unused_mut)]
     let mut output = toml::to_string(&filtered_lock_file).unwrap();
 
-    #[cfg(feature = "default")]
-    output.push_str(&format!("\n{}", "default"));
-    #[cfg(feature = "bundle-default")]
-    output.push_str(&format!("\n{}", "default"));
-    #[cfg(feature = "bundle-sdk")]
-    output.push_str(&format!("\n{}", "bundle-sdk"));
-    #[cfg(feature = "plugin-vade-signer")]
-    output.push_str(&format!("\n{}", "plugin-vade-signer"));
-    #[cfg(feature = "plugin-did-sidetree")]
-    output.push_str(&format!("\n{}", "plugin-did-sidetree"));
-    #[cfg(feature = "plugin-did-substrate")]
-    output.push_str(&format!("\n{}", "plugin-did-substrate"));
-    #[cfg(feature = "plugin-didcomm")]
-    output.push_str(&format!("\n{}", "plugin-didcomm"));
-    #[cfg(feature = "plugin-jwt-vc")]
-    output.push_str(&format!("\n{}", "plugin-jwt-vc"));
-    #[cfg(feature = "plugin-vc-zkp-bbs")]
-    output.push_str(&format!("\n{}", "plugin-vc-zkp-bbs"));
-    #[cfg(feature = "capability-didcomm")]
-    output.push_str(&format!("\n{}", "capability-didcomm"));
-    #[cfg(feature = "capability-did-read")]
-    output.push_str(&format!("\n{}", "capability-did-read"));
-    #[cfg(feature = "capability-did-write")]
-    output.push_str(&format!("\n{}", "capability-did-write"));
-    #[cfg(feature = "capability-sdk")]
-    output.push_str(&format!("\n{}", "capability-sdk"));
-    #[cfg(feature = "capability-vc-zkp")]
-    output.push_str(&format!("\n{}", "capability-vc-zkp"));
-    #[cfg(feature = "capability-target-c-lib")]
-    output.push_str(&format!("\n{}", "capability-target-c-lib"));
-    #[cfg(feature = "capability-target-cli")]
-    output.push_str(&format!("\n{}", "capability-target-cli"));
-    #[cfg(feature = "capability-target-java-lib")]
-    output.push_str(&format!("\n{}", "capability-target-java-lib"));
-    #[cfg(feature = "capability-target-wasm")]
-    output.push_str(&format!("\n{}", "capability-target-wasm"));
+    append_features![
+        output,
+        "default",
+        "bundle-default",
+        "bundle-sdk",
+        "plugin-did-sidetree",
+        "plugin-did-substrate",
+        "plugin-didcomm",
+        "plugin-jwt-vc",
+        "plugin-signer",
+        "plugin-vc-zkp-bbs",
+        "capability-didcomm",
+        "capability-did-read",
+        "capability-did-write",
+        "capability-sdk",
+        "capability-vc-zkp",
+        "capability-target-c-lib",
+        "capability-target-cli",
+        "capability-target-java-lib",
+        "capability-target-wasm"
+    ];
 
     write!(f, "{}", &output).unwrap();
 }

--- a/build.rs
+++ b/build.rs
@@ -35,5 +35,46 @@ fn main() {
     let dest_path = Path::new(&env::var("OUT_DIR").unwrap()).join("build_info.txt");
     let mut f = BufWriter::new(File::create(&dest_path).unwrap());
 
-    write!(f, "{}", toml::to_string(&filtered_lock_file).unwrap()).unwrap();
+    // variable might be needlessly mutable due to the following feature listing not matching
+    #[allow(unused_mut)]
+    let mut output = toml::to_string(&filtered_lock_file).unwrap();
+
+    #[cfg(feature = "default")]
+    output.push_str(&format!("\n{}", "default"));
+    #[cfg(feature = "bundle-default")]
+    output.push_str(&format!("\n{}", "default"));
+    #[cfg(feature = "bundle-sdk")]
+    output.push_str(&format!("\n{}", "bundle-sdk"));
+    #[cfg(feature = "plugin-vade-signer")]
+    output.push_str(&format!("\n{}", "plugin-vade-signer"));
+    #[cfg(feature = "plugin-did-sidetree")]
+    output.push_str(&format!("\n{}", "plugin-did-sidetree"));
+    #[cfg(feature = "plugin-did-substrate")]
+    output.push_str(&format!("\n{}", "plugin-did-substrate"));
+    #[cfg(feature = "plugin-didcomm")]
+    output.push_str(&format!("\n{}", "plugin-didcomm"));
+    #[cfg(feature = "plugin-jwt-vc")]
+    output.push_str(&format!("\n{}", "plugin-jwt-vc"));
+    #[cfg(feature = "plugin-vc-zkp-bbs")]
+    output.push_str(&format!("\n{}", "plugin-vc-zkp-bbs"));
+    #[cfg(feature = "capability-didcomm")]
+    output.push_str(&format!("\n{}", "capability-didcomm"));
+    #[cfg(feature = "capability-did-read")]
+    output.push_str(&format!("\n{}", "capability-did-read"));
+    #[cfg(feature = "capability-did-write")]
+    output.push_str(&format!("\n{}", "capability-did-write"));
+    #[cfg(feature = "capability-sdk")]
+    output.push_str(&format!("\n{}", "capability-sdk"));
+    #[cfg(feature = "capability-vc-zkp")]
+    output.push_str(&format!("\n{}", "capability-vc-zkp"));
+    #[cfg(feature = "capability-target-c-lib")]
+    output.push_str(&format!("\n{}", "capability-target-c-lib"));
+    #[cfg(feature = "capability-target-cli")]
+    output.push_str(&format!("\n{}", "capability-target-cli"));
+    #[cfg(feature = "capability-target-java-lib")]
+    output.push_str(&format!("\n{}", "capability-target-java-lib"));
+    #[cfg(feature = "capability-target-wasm")]
+    output.push_str(&format!("\n{}", "capability-target-wasm"));
+
+    write!(f, "{}", &output).unwrap();
 }

--- a/src/api/vade_bundle.rs
+++ b/src/api/vade_bundle.rs
@@ -1,31 +1,23 @@
 use std::error::Error;
-use vade::Vade;
-#[cfg(feature = "didcomm")]
-use vade_didcomm::VadeDidComm;
-#[cfg(feature = "vc-zkp-bbs")]
-use vade_evan_bbs::VadeEvanBbs;
-// TODO: vade_evan_cl will be enabled when it is published to crates.io
-// #[cfg(feature = "vc-zkp-cl")]
-// use vade_evan_cl::VadeEvanCl;
-#[cfg(feature = "sdk")]
+#[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
 use std::os::raw::c_void;
-#[cfg(feature = "did-substrate")]
+use vade::Vade;
+#[cfg(feature = "plugin-didcomm")]
+use vade_didcomm::VadeDidComm;
+#[cfg(feature = "plugin-vc-zkp-bbs")]
+use vade_evan_bbs::VadeEvanBbs;
+#[cfg(feature = "plugin-did-substrate")]
 use vade_evan_substrate::{ResolverConfig, VadeEvanSubstrate};
-#[cfg(feature = "vc-jwt")]
+#[cfg(feature = "plugin-jwt-vc")]
 use vade_jwt_vc::VadeJwtVC;
-#[cfg(feature = "did-sidetree")]
+#[cfg(feature = "plugin-did-sidetree")]
 use vade_sidetree::VadeSidetree;
-#[cfg(any(
-    feature = "did-substrate",
-    feature = "vc-zkp-bbs",
-    feature = "vc-zkp-cl",
-    feature = "vc-jwt"
-))]
+#[cfg(feature = "plugin-vade-signer")]
 use vade_signer::{LocalSigner, RemoteSigner, Signer};
-#[cfg(feature = "did-universal-resolver")]
+#[cfg(feature = "plugin-did-universal-resolver")]
 use vade_universal_resolver::VadeUniversalResolver;
 
-#[cfg(feature = "sdk")]
+#[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
 use crate::in3_request_list::ResolveHttpRequest;
 
 fn get_signer(signer: &str) -> Box<dyn Signer> {
@@ -40,111 +32,78 @@ fn get_signer(signer: &str) -> Box<dyn Signer> {
     }
 }
 
+// variables might be unused depending on feature combination
+#[allow(unused_variables)]
 pub fn get_vade(
     target: &str,
     signer: &str,
-    #[cfg(feature = "sdk")] request_id: *const c_void,
-    #[cfg(feature = "sdk")] _request_function_callback: ResolveHttpRequest,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] request_id: *const c_void,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+    _request_function_callback: ResolveHttpRequest,
 ) -> Result<Vade, Box<dyn Error>> {
     let mut vade = Vade::new();
 
-    #[cfg(feature = "did-substrate")]
+    #[cfg(feature = "plugin-did-substrate")]
     vade.register_plugin(Box::from(get_vade_evan_substrate(
         target,
         signer,
-        #[cfg(feature = "sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_id,
     )?));
-    #[cfg(feature = "did-universal-resolver")]
+    #[cfg(feature = "plugin-did-universal-resolver")]
     vade.register_plugin(Box::from(get_vade_universal_resolver(
-        #[cfg(feature = "sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_id,
-        #[cfg(feature = "sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_function_callback,
     )?));
-    #[cfg(feature = "did-sidetree")]
+    #[cfg(feature = "plugin-did-sidetree")]
     vade.register_plugin(Box::from(get_vade_sidetree(
-        #[cfg(feature = "sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_id,
     )?));
-    // #[cfg(feature = "vc-zkp-cl")]
-    // vade.register_plugin(Box::from(get_vade_evan_cl(
-    //     target,
-    //     signer,
-    //     #[cfg(feature = "sdk")]
-    //     request_id,
-    //     #[cfg(feature = "sdk")]
-    //     request_function_callback
-    // )?));
-    #[cfg(feature = "vc-zkp-bbs")]
+    #[cfg(feature = "plugin-vc-zkp-bbs")]
     vade.register_plugin(Box::from(get_vade_evan_bbs(
         signer,
-        #[cfg(feature = "sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_id,
     )?));
 
-    #[cfg(feature = "vc-jwt")]
+    #[cfg(feature = "plugin-jwt-vc")]
     vade.register_plugin(Box::from(get_vade_jwt_vc(
         signer,
-        #[cfg(feature = "sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_id,
     )?));
 
-    #[cfg(feature = "didcomm")]
+    #[cfg(feature = "plugin-didcomm")]
     vade.register_plugin(Box::from(VadeDidComm::new()?));
 
     Ok(vade)
 }
 
-// #[cfg(feature = "vc-zkp-cl")]
-// fn get_vade_evan_cl(
-//     target: &str,
-//     signer: &str,
-//     #[cfg(feature = "sdk")]
-//     request_id: *const c_void,
-//     #[cfg(feature = "sdk")]
-//     request_function_callback: ResolveHttpRequest
-// ) -> Result<VadeEvanCl, Box<dyn Error>> {
-//     let mut vade = Vade::new();
-
-//     #[cfg(feature = "did-substrate")]
-//     vade.register_plugin(Box::from(get_vade_evan_substrate(target, signer, #[cfg(feature = "sdk")] request_id)?));
-//     #[cfg(feature = "did-universal-resolver")]
-//     vade.register_plugin(Box::from(get_vade_universal_resolver(
-//         #[cfg(feature = "sdk")]
-//         request_id,
-//         #[cfg(feature = "sdk")]
-//         request_function_callback
-//     )?));
-//     #[cfg(feature = "did-sidetree")]
-//     vade.register_plugin(Box::from(get_vade_sidetree(#[cfg(feature = "sdk")] request_id)?));
-
-//     let signer: Box<dyn Signer> = get_signer(signer);
-//     Ok(VadeEvanCl::new(vade, signer))
-// }
-
-#[cfg(feature = "vc-zkp-bbs")]
+#[cfg(feature = "plugin-vc-zkp-bbs")]
 fn get_vade_evan_bbs(
     signer: &str,
-    #[cfg(feature = "sdk")] _request_id: *const c_void,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] _request_id: *const c_void,
 ) -> Result<VadeEvanBbs, Box<dyn Error>> {
     let signer: Box<dyn Signer> = get_signer(signer);
     Ok(VadeEvanBbs::new(signer))
 }
 
-#[cfg(feature = "vc-jwt")]
+#[cfg(feature = "plugin-jwt-vc")]
 fn get_vade_jwt_vc(
     signer: &str,
-    #[cfg(feature = "sdk")] _request_id: *const c_void,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] _request_id: *const c_void,
 ) -> Result<VadeJwtVC, Box<dyn Error>> {
     Ok(VadeJwtVC::new(get_signer(signer)))
 }
 
-#[cfg(feature = "did-substrate")]
+#[cfg(feature = "plugin-did-substrate")]
 fn get_vade_evan_substrate(
     target: &str,
     signer: &str,
-    #[cfg(feature = "sdk")] _request_id: *const c_void,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] _request_id: *const c_void,
 ) -> Result<VadeEvanSubstrate, Box<dyn Error>> {
     Ok(VadeEvanSubstrate::new(ResolverConfig {
         signer: get_signer(signer),
@@ -152,23 +111,24 @@ fn get_vade_evan_substrate(
     }))
 }
 
-#[cfg(feature = "did-universal-resolver")]
+#[cfg(feature = "plugin-did-universal-resolver")]
 fn get_vade_universal_resolver(
-    #[cfg(feature = "sdk")] request_id: *const c_void,
-    #[cfg(feature = "sdk")] request_function_callback: ResolveHttpRequest,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] request_id: *const c_void,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+    request_function_callback: ResolveHttpRequest,
 ) -> Result<VadeUniversalResolver, Box<dyn Error>> {
     Ok(VadeUniversalResolver::new(
         std::env::var("RESOLVER_URL").ok(),
-        #[cfg(feature = "sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_id,
-        #[cfg(feature = "sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_function_callback,
     ))
 }
 
-#[cfg(feature = "did-sidetree")]
+#[cfg(feature = "plugin-did-sidetree")]
 fn get_vade_sidetree(
-    #[cfg(feature = "sdk")] _request_id: *const c_void,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] _request_id: *const c_void,
 ) -> Result<VadeSidetree, Box<dyn Error>> {
     Ok(VadeSidetree::new(std::env::var("SIDETREE_API_URL").ok()))
 }

--- a/src/api/vade_bundle.rs
+++ b/src/api/vade_bundle.rs
@@ -20,6 +20,11 @@ use vade_universal_resolver::VadeUniversalResolver;
 #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
 use crate::in3_request_list::ResolveHttpRequest;
 
+#[cfg(any(
+    feature = "plugin-vc-zkp-bbs",
+    feature = "plugin-jwt-vc",
+    feature = "plugin-did-substrate"
+))]
 fn get_signer(signer: &str) -> Box<dyn Signer> {
     if signer.starts_with("remote") {
         Box::new(RemoteSigner::new(

--- a/src/api/vade_bundle.rs
+++ b/src/api/vade_bundle.rs
@@ -12,7 +12,7 @@ use vade_evan_substrate::{ResolverConfig, VadeEvanSubstrate};
 use vade_jwt_vc::VadeJwtVC;
 #[cfg(feature = "plugin-did-sidetree")]
 use vade_sidetree::VadeSidetree;
-#[cfg(feature = "plugin-vade-signer")]
+#[cfg(feature = "plugin-signer")]
 use vade_signer::{LocalSigner, RemoteSigner, Signer};
 #[cfg(feature = "plugin-did-universal-resolver")]
 use vade_universal_resolver::VadeUniversalResolver;

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -14,11 +14,11 @@
   limitations under the License.
 */
 
-#[cfg(feature = "capability-sdk")]
+#[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
 use std::os::raw::c_void;
 use vade::Vade;
 
-#[cfg(feature = "capability-sdk")]
+#[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
 use crate::in3_request_list::ResolveHttpRequest;
 use crate::{
     api::{vade_bundle::get_vade, vade_evan_error::VadeEvanError},
@@ -58,9 +58,9 @@ impl VadeEvan {
         match get_vade(
             &config.target,
             &config.signer,
-            #[cfg(feature = "capability-sdk")]
+            #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
             config.request_id,
-            #[cfg(feature = "capability-sdk")]
+            #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
             config.request_function_callback,
         ) {
             Ok(vade) => Ok(Self { vade }),

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -14,11 +14,11 @@
   limitations under the License.
 */
 
-#[cfg(feature = "sdk")]
+#[cfg(feature = "capability-sdk")]
 use std::os::raw::c_void;
 use vade::Vade;
 
-#[cfg(feature = "sdk")]
+#[cfg(feature = "capability-sdk")]
 use crate::in3_request_list::ResolveHttpRequest;
 use crate::{
     api::{vade_bundle::get_vade, vade_evan_error::VadeEvanError},
@@ -41,9 +41,9 @@ fn get_first_result(results: Vec<Option<String>>) -> Result<String, VadeEvanErro
 pub struct VadeEvanConfig<'a> {
     pub target: &'a str,
     pub signer: &'a str,
-    #[cfg(feature = "sdk")]
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
     pub request_id: *const c_void,
-    #[cfg(feature = "sdk")]
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
     pub request_function_callback: ResolveHttpRequest,
 }
 
@@ -58,9 +58,9 @@ impl VadeEvan {
         match get_vade(
             &config.target,
             &config.signer,
-            #[cfg(feature = "sdk")]
+            #[cfg(feature = "capability-sdk")]
             config.request_id,
-            #[cfg(feature = "sdk")]
+            #[cfg(feature = "capability-sdk")]
             config.request_function_callback,
         ) {
             Ok(vade) => Ok(Self { vade }),

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -15,12 +15,12 @@
 */
 
 use crate::api::{VadeEvan, VadeEvanConfig, VadeEvanError, DEFAULT_SIGNER, DEFAULT_TARGET};
-#[cfg(feature = "sdk")]
+#[cfg(feature = "capability-sdk")]
 use crate::in3_request_list::ResolveHttpRequest;
 use serde::Serialize;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
-#[cfg(feature = "sdk")]
+#[cfg(feature = "capability-sdk")]
 use std::os::raw::c_void;
 use std::slice;
 use std::{collections::HashMap, error::Error};
@@ -36,13 +36,13 @@ pub struct Response {
 }
 
 macro_rules! execute_vade_function {
-    ($func_name:ident, $did_or_method:expr, $config:expr, #[cfg(feature = "sdk")] $request_id:expr, #[cfg(feature = "sdk")] $callback:expr) => {
+    ($func_name:ident, $did_or_method:expr, $config:expr, #[cfg(feature = "capability-sdk")] $request_id:expr, #[cfg(feature = "capability-sdk")] $callback:expr) => {
         async {
             let mut vade_evan = get_vade_evan(
                 Some(&$config.to_string()),
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 $request_id,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 $callback,
             )
             .map_err(stringify_generic_error)?;
@@ -53,13 +53,13 @@ macro_rules! execute_vade_function {
         }
     };
 
-    ($func_name:ident, $options:expr, $payload:expr, $config:expr,  #[cfg(feature = "sdk")] $request_id:expr, #[cfg(feature = "sdk")] $callback:expr) => {
+    ($func_name:ident, $options:expr, $payload:expr, $config:expr,  #[cfg(feature = "capability-sdk")] $request_id:expr, #[cfg(feature = "capability-sdk")] $callback:expr) => {
         async {
             let mut vade_evan = get_vade_evan(
                 Some(&$config),
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 $request_id,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 $callback,
             )
             .map_err(stringify_generic_error)?;
@@ -70,13 +70,13 @@ macro_rules! execute_vade_function {
         }
     };
 
-    ($func_name:ident, $did_or_method:expr, $options:expr, $payload:expr, $config:expr, #[cfg(feature = "sdk")] $request_id:expr, #[cfg(feature = "sdk")] $callback:expr) => {
+    ($func_name:ident, $did_or_method:expr, $options:expr, $payload:expr, $config:expr, #[cfg(feature = "capability-sdk")] $request_id:expr, #[cfg(feature = "capability-sdk")] $callback:expr) => {
         async {
             let mut vade_evan = get_vade_evan(
                 Some(&$config),
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 $request_id,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 $callback,
             )
             .map_err(stringify_generic_error)?;
@@ -87,13 +87,13 @@ macro_rules! execute_vade_function {
         }
     };
 
-    ($func_name:ident, $did_or_method:expr, $function:expr, $options:expr, $payload:expr, $config:expr,  #[cfg(feature = "sdk")] $request_id:expr, #[cfg(feature = "sdk")] $callback:expr) => {
+    ($func_name:ident, $did_or_method:expr, $function:expr, $options:expr, $payload:expr, $config:expr,  #[cfg(feature = "capability-sdk")] $request_id:expr, #[cfg(feature = "capability-sdk")] $callback:expr) => {
         async {
             let mut vade_evan = get_vade_evan(
                 Some(&$config),
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 $request_id,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 $callback,
             )
             .map_err(stringify_generic_error)?;
@@ -116,8 +116,8 @@ fn stringify_vade_evan_error(err: VadeEvanError) -> String {
 #[allow(unused_variables)] // allow possibly unused variables due to feature mix
 pub fn get_vade_evan(
     config: Option<&String>,
-    #[cfg(feature = "sdk")] request_id: *const c_void,
-    #[cfg(feature = "sdk")] request_function_callback: ResolveHttpRequest,
+    #[cfg(feature = "capability-sdk")] request_id: *const c_void,
+    #[cfg(feature = "capability-sdk")] request_function_callback: ResolveHttpRequest,
 ) -> Result<VadeEvan, Box<dyn Error>> {
     let config_values =
         get_config_values(config, vec!["signer".to_string(), "target".to_string()])?;
@@ -131,9 +131,9 @@ pub fn get_vade_evan(
     return VadeEvan::new(VadeEvanConfig {
         target,
         signer: signer_config,
-        #[cfg(feature = "sdk")]
+        #[cfg(feature = "capability-sdk")]
         request_id,
-        #[cfg(feature = "sdk")]
+        #[cfg(feature = "capability-sdk")]
         request_function_callback,
     })
     .map_err(|err| Box::from(format!("could not create VadeEvan instance; {}", &err)));
@@ -188,9 +188,9 @@ pub extern "C" fn execute_vade(
     arguments: *const *const c_char,
     num_of_args: usize,
     options: *const c_char,
-    #[cfg(not(feature = "sdk"))] config: *const c_char,
-    #[cfg(feature = "sdk")] config: *const c_void,
-    #[cfg(feature = "sdk")] request_function_callback: ResolveHttpRequest,
+    #[cfg(not(feature = "capability-sdk"))] config: *const c_char,
+    #[cfg(feature = "capability-sdk")] config: *const c_void,
+    #[cfg(feature = "capability-sdk")] request_function_callback: ResolveHttpRequest,
 ) -> *const c_char {
     let func = unsafe { CStr::from_ptr(func_name).to_string_lossy().into_owned() };
     let args_array: &[*const c_char] =
@@ -204,21 +204,21 @@ pub extern "C" fn execute_vade(
 
     let mut str_options = String::new();
 
-    #[cfg(not(feature = "sdk"))]
+    #[cfg(not(feature = "capability-sdk"))]
     let mut str_config = String::new();
-    #[cfg(feature = "sdk")]
+    #[cfg(feature = "capability-sdk")]
     let str_config = String::new();
 
     if !options.is_null() {
         str_options = unsafe { CStr::from_ptr(options).to_string_lossy().into_owned() };
     }
 
-    #[cfg(not(feature = "sdk"))]
+    #[cfg(not(feature = "capability-sdk"))]
     if !config.is_null() {
         str_config = unsafe { CStr::from_ptr(config).to_string_lossy().into_owned() };
     }
 
-    #[cfg(feature = "sdk")]
+    #[cfg(feature = "capability-sdk")]
     let ptr_request_list = config as *mut c_void;
 
     let no_args = String::from("");
@@ -230,19 +230,19 @@ pub extern "C" fn execute_vade(
         .expect("Failed to create runtime");
 
     let result = match func.as_str() {
-        #[cfg(feature = "did-read")]
+        #[cfg(feature = "capability-did-read")]
         "did_resolve" => runtime.block_on({
             execute_vade_function!(
                 did_resolve,
                 arguments_vec.get(0).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(feature = "did-write")]
+        #[cfg(feature = "capability-did-write")]
         "did_create" => runtime.block_on({
             execute_vade_function!(
                 did_create,
@@ -250,13 +250,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(feature = "did-write")]
+        #[cfg(feature = "capability-did-write")]
         "did_update" => runtime.block_on({
             execute_vade_function!(
                 did_update,
@@ -264,53 +264,39 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(feature = "didcomm")]
+        #[cfg(feature = "capability-didcomm")]
         "didcomm_receive" => runtime.block_on({
             execute_vade_function!(
                 didcomm_receive,
                 &str_options,
                 arguments_vec.get(0).unwrap_or_else(|| &no_args).to_owned(),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(feature = "didcomm")]
+        #[cfg(feature = "capability-didcomm")]
         "didcomm_send" => runtime.block_on({
             execute_vade_function!(
                 didcomm_send,
                 str_options,
                 arguments_vec.get(0).unwrap_or_else(|| &no_args).to_owned(),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(feature = "vc-zkp-cl")]
-        "vc_zkp_create_credential_definition" => runtime.block_on({
-            execute_vade_function!(
-                vc_zkp_create_credential_definition,
-                arguments_vec.get(0).unwrap_or_else(|| &no_args),
-                &str_options,
-                arguments_vec.get(1).unwrap_or_else(|| &no_args),
-                str_config,
-                #[cfg(feature = "sdk")]
-                ptr_request_list,
-                #[cfg(feature = "sdk")]
-                request_function_callback
-            )
-        }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_create_credential_offer" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_create_credential_offer,
@@ -318,13 +304,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_create_credential_proposal" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_create_credential_proposal,
@@ -332,13 +318,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_create_credential_schema" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_create_credential_schema,
@@ -346,13 +332,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_create_revocation_registry_definition" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_create_revocation_registry_definition,
@@ -360,13 +346,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_update_revocation_registry" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_update_revocation_registry,
@@ -374,13 +360,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs", feature = "vc-jwt"))]
+        #[cfg(feature = "capability-vc-zkp")]
         "vc_zkp_issue_credential" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_issue_credential,
@@ -388,13 +374,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_finish_credential" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_finish_credential,
@@ -402,13 +388,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_present_proof" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_present_proof,
@@ -416,13 +402,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_request_credential" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_request_credential,
@@ -430,13 +416,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_request_proof" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_request_proof,
@@ -444,13 +430,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "vc_zkp_revoke_credential" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_revoke_credential,
@@ -458,13 +444,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs", feature = "vc-jwt"))]
+        #[cfg(feature = "capability-vc-zkp")]
         "vc_zkp_verify_proof" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_verify_proof,
@@ -472,13 +458,13 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "run_custom_function" => runtime.block_on({
             execute_vade_function!(
                 run_custom_function,
@@ -487,17 +473,17 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(2).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 ptr_request_list,
-                #[cfg(feature = "sdk")]
+                #[cfg(feature = "capability-sdk")]
                 request_function_callback
             )
         }),
         "get_version_info" => get_vade_evan(
             Some(&str_config),
-            #[cfg(feature = "sdk")]
+            #[cfg(feature = "capability-sdk")]
             ptr_request_list,
-            #[cfg(feature = "sdk")]
+            #[cfg(feature = "capability-sdk")]
             request_function_callback,
         )
         .map_err(stringify_generic_error)

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -15,12 +15,12 @@
 */
 
 use crate::api::{VadeEvan, VadeEvanConfig, VadeEvanError, DEFAULT_SIGNER, DEFAULT_TARGET};
-#[cfg(feature = "capability-sdk")]
+#[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
 use crate::in3_request_list::ResolveHttpRequest;
 use serde::Serialize;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
-#[cfg(feature = "capability-sdk")]
+#[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
 use std::os::raw::c_void;
 use std::slice;
 use std::{collections::HashMap, error::Error};
@@ -36,13 +36,13 @@ pub struct Response {
 }
 
 macro_rules! execute_vade_function {
-    ($func_name:ident, $did_or_method:expr, $config:expr, #[cfg(feature = "capability-sdk")] $request_id:expr, #[cfg(feature = "capability-sdk")] $callback:expr) => {
+    ($func_name:ident, $did_or_method:expr, $config:expr, #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] $request_id:expr, #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] $callback:expr) => {
         async {
             let mut vade_evan = get_vade_evan(
                 Some(&$config.to_string()),
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 $request_id,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 $callback,
             )
             .map_err(stringify_generic_error)?;
@@ -53,13 +53,13 @@ macro_rules! execute_vade_function {
         }
     };
 
-    ($func_name:ident, $options:expr, $payload:expr, $config:expr,  #[cfg(feature = "capability-sdk")] $request_id:expr, #[cfg(feature = "capability-sdk")] $callback:expr) => {
+    ($func_name:ident, $options:expr, $payload:expr, $config:expr,  #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] $request_id:expr, #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] $callback:expr) => {
         async {
             let mut vade_evan = get_vade_evan(
                 Some(&$config),
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 $request_id,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 $callback,
             )
             .map_err(stringify_generic_error)?;
@@ -70,13 +70,13 @@ macro_rules! execute_vade_function {
         }
     };
 
-    ($func_name:ident, $did_or_method:expr, $options:expr, $payload:expr, $config:expr, #[cfg(feature = "capability-sdk")] $request_id:expr, #[cfg(feature = "capability-sdk")] $callback:expr) => {
+    ($func_name:ident, $did_or_method:expr, $options:expr, $payload:expr, $config:expr, #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] $request_id:expr, #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] $callback:expr) => {
         async {
             let mut vade_evan = get_vade_evan(
                 Some(&$config),
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 $request_id,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 $callback,
             )
             .map_err(stringify_generic_error)?;
@@ -87,13 +87,13 @@ macro_rules! execute_vade_function {
         }
     };
 
-    ($func_name:ident, $did_or_method:expr, $function:expr, $options:expr, $payload:expr, $config:expr,  #[cfg(feature = "capability-sdk")] $request_id:expr, #[cfg(feature = "capability-sdk")] $callback:expr) => {
+    ($func_name:ident, $did_or_method:expr, $function:expr, $options:expr, $payload:expr, $config:expr,  #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] $request_id:expr, #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] $callback:expr) => {
         async {
             let mut vade_evan = get_vade_evan(
                 Some(&$config),
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 $request_id,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 $callback,
             )
             .map_err(stringify_generic_error)?;
@@ -116,8 +116,9 @@ fn stringify_vade_evan_error(err: VadeEvanError) -> String {
 #[allow(unused_variables)] // allow possibly unused variables due to feature mix
 pub fn get_vade_evan(
     config: Option<&String>,
-    #[cfg(feature = "capability-sdk")] request_id: *const c_void,
-    #[cfg(feature = "capability-sdk")] request_function_callback: ResolveHttpRequest,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] request_id: *const c_void,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+    request_function_callback: ResolveHttpRequest,
 ) -> Result<VadeEvan, Box<dyn Error>> {
     let config_values =
         get_config_values(config, vec!["signer".to_string(), "target".to_string()])?;
@@ -131,9 +132,9 @@ pub fn get_vade_evan(
     return VadeEvan::new(VadeEvanConfig {
         target,
         signer: signer_config,
-        #[cfg(feature = "capability-sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_id,
-        #[cfg(feature = "capability-sdk")]
+        #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
         request_function_callback,
     })
     .map_err(|err| Box::from(format!("could not create VadeEvan instance; {}", &err)));
@@ -182,15 +183,26 @@ fn get_config_values(
     Ok(vec)
 }
 
+/// Executes a vade call.
+///
+/// About the `config` argument setup used here:
+///
+/// - if built for C and having sdk capability enabled: type is `*const c_void`
+/// - for any other build: type is `*const c_char`
+/// - if built for Java and having sdk capability enabled: it is an unused argument,
+///   so prefix it with `_`
 #[no_mangle]
 pub extern "C" fn execute_vade(
     func_name: *const c_char,
     arguments: *const *const c_char,
     num_of_args: usize,
     options: *const c_char,
-    #[cfg(not(feature = "capability-sdk"))] config: *const c_char,
-    #[cfg(feature = "capability-sdk")] config: *const c_void,
-    #[cfg(feature = "capability-sdk")] request_function_callback: ResolveHttpRequest,
+    #[cfg(all(feature = "target-java-lib", not(feature = "capability-sdk")))] config: *const c_char,
+    #[cfg(all(feature = "target-java-lib", feature = "capability-sdk"))] _config: *const c_char,
+    #[cfg(all(feature = "target-c-lib", not(feature = "capability-sdk")))] config: *const c_char,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))] config: *const c_void,
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+    request_function_callback: ResolveHttpRequest,
 ) -> *const c_char {
     let func = unsafe { CStr::from_ptr(func_name).to_string_lossy().into_owned() };
     let args_array: &[*const c_char] =
@@ -218,7 +230,7 @@ pub extern "C" fn execute_vade(
         str_config = unsafe { CStr::from_ptr(config).to_string_lossy().into_owned() };
     }
 
-    #[cfg(feature = "capability-sdk")]
+    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
     let ptr_request_list = config as *mut c_void;
 
     let no_args = String::from("");
@@ -236,9 +248,9 @@ pub extern "C" fn execute_vade(
                 did_resolve,
                 arguments_vec.get(0).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -250,9 +262,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -264,9 +276,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -277,9 +289,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(0).unwrap_or_else(|| &no_args).to_owned(),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -290,9 +302,9 @@ pub extern "C" fn execute_vade(
                 str_options,
                 arguments_vec.get(0).unwrap_or_else(|| &no_args).to_owned(),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -304,9 +316,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -318,9 +330,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -332,9 +344,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -346,9 +358,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -360,9 +372,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -374,9 +386,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -388,9 +400,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -402,9 +414,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -416,9 +428,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -430,9 +442,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -444,9 +456,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -458,9 +470,9 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(1).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
@@ -473,17 +485,17 @@ pub extern "C" fn execute_vade(
                 &str_options,
                 arguments_vec.get(2).unwrap_or_else(|| &no_args),
                 str_config,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 ptr_request_list,
-                #[cfg(feature = "capability-sdk")]
+                #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
                 request_function_callback
             )
         }),
         "get_version_info" => get_vade_evan(
             Some(&str_config),
-            #[cfg(feature = "capability-sdk")]
+            #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
             ptr_request_list,
-            #[cfg(feature = "capability-sdk")]
+            #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
             request_function_callback,
         )
         .map_err(stringify_generic_error)

--- a/src/java_lib.rs
+++ b/src/java_lib.rs
@@ -2,7 +2,7 @@ use crate::c_lib::execute_vade;
 use jni::objects::{JClass, JString};
 use jni::sys::{jarray, jstring};
 use jni::JNIEnv;
-use std::ffi::{CStr,CString};
+use std::ffi::{CStr, CString};
 use std::os::raw::c_char;
 
 #[no_mangle]
@@ -30,7 +30,7 @@ pub extern "system" fn Java_com_vade_evan_Vade_executeVade(
             .expect("Couldn't get char array options");
     }
 
-    let mut c_str_config= empty_owned_string.as_ptr();
+    let mut c_str_config = empty_owned_string.as_ptr();
     if !config.is_null() {
         c_str_config = env
             .get_string_utf_chars(config)
@@ -40,7 +40,7 @@ pub extern "system" fn Java_com_vade_evan_Vade_executeVade(
     let mut arguments_vec: Vec<*const c_char> = Vec::new();
     let arg_count = env
         .get_array_length(arguments)
-        .expect("Couldn't get arrguments array length");
+        .expect("Couldn't get arguments array length");
 
     for i in 0..arg_count {
         let array_element = env

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,10 @@
   limitations under the License.
 */
 
-#[cfg(feature = "capability-sdk")]
+#[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
 mod in3_request_list;
 
-#[cfg(feature = "target-c-lib")]
+#[cfg(feature = "capability-c-lib")]
 mod c_lib;
 #[cfg(feature = "target-java-lib")]
 mod java_lib;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,12 +14,12 @@
   limitations under the License.
 */
 
-#[cfg(feature = "sdk")]
+#[cfg(feature = "capability-sdk")]
 mod in3_request_list;
 
-#[cfg(feature = "c-lib")]
+#[cfg(feature = "target-c-lib")]
 mod c_lib;
-#[cfg(feature = "java-lib")]
+#[cfg(feature = "target-java-lib")]
 mod java_lib;
 // wasm only
 #[cfg(target_arch = "wasm32")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,212 +192,249 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn add_subcommand_did<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>, Box<dyn std::error::Error>> {
+    cfg_if::cfg_if! {
+        if #[cfg(any(feature = "capability-did-read", feature = "capability-did-write"))] {
+            let app = app.subcommand(
+                SubCommand::with_name("did")
+                    .about("Works with DIDs.")
+                    .setting(AppSettings::DeriveDisplayOrder)
+                    .setting(AppSettings::SubcommandRequiredElseHelp)
+                    .subcommand(
+                        SubCommand::with_name("create")
+                            .about("Creates a new DID on substrate.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("resolve")
+                            .about("Fetch data about a DID, which returns this DID's DID document.")
+                            .arg(get_clap_argument("did")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("update")
+                            .about(r###"Updates data related to a DID. Two updates are supported depending on the value of `options.operation`.
+                - whitelistIdentity: whitelists identity `did` on substrate, this is required to be able to perform transactions this this identity
+                - setDidDocument: sets the DID document for `did`"###)
+                            .arg(get_clap_argument("did")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+            );
+        } else {
+        }
+    }
+
+    Ok(app)
+}
+
+fn add_subcommand_didcomm<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>, Box<dyn std::error::Error>> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "capability-didcomm")] {
+            let app = app.subcommand(
+                SubCommand::with_name("didcomm")
+                    .about("Processes DIDComm message")
+                    .setting(AppSettings::DeriveDisplayOrder)
+                    .setting(AppSettings::SubcommandRequiredElseHelp)
+                    .subcommand(
+                        SubCommand::with_name("send")
+                            .about(r###"Prepare a plain DIDComm json message to be sent, including encryption and protocol specific message enhancement.
+        The DIDComm options can include a shared secret to encrypt the message with a specific key.
+        If no key was given and the message should be encrypted (depends on protocol implementation), the DIDComm keypair from a db provider will be used."###)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("receive")
+                            .about(r###"Receive a plain DIDComm json message, including decryption and protocol specific message parsing.
+        The DIDComm options can include a shared secret to encrypt the message with a specific key.
+        If no key was given and the message is encrypted the DIDComm keypair from a db will be used."###)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("create_keys")
+                            .about(r###"Create X25519 secret/public keys, which can be used in options while sending and receiving DIDComm message."###)
+                    )
+                    .subcommand(
+                        SubCommand::with_name("query_didcomm_messages")
+                            .about(r###"Query stored DIDComm messages by prefix (message_{thid}_*) or messageid (message_{thid}_{msgid})."###)
+                            .arg(get_clap_argument("payload")?),
+                    )
+            );
+        } else {
+        }
+    }
+
+    Ok(app)
+}
+
+fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>, Box<dyn std::error::Error>> {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "capability-vc-zkp")] {
+            let app = app.subcommand(
+                SubCommand::with_name("vc_zkp")
+                    .about("Works with zero knowledge proof VCs.")
+                    .setting(AppSettings::DeriveDisplayOrder)
+                    .setting(AppSettings::SubcommandRequiredElseHelp)
+                    .subcommand(
+                        SubCommand::with_name("create_master_secret")
+                            .about("Creates a new master secret.")
+                            .arg(get_clap_argument("options")?)
+                    )
+                    .subcommand(
+                        SubCommand::with_name("create_new_keys")
+                            .about("Creates a new key pair and stores it in the DID document.")
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("generate_safe_prime")
+                            .about("Generates a new safe prime number, that can be used in combination with `create_credential_definition` to for key pair generation.")
+                    )
+                    .subcommand(
+                        SubCommand::with_name("create_credential_definition")
+                            .about("Creates a new credential definition and stores the public part on-chain. The private part (key) needs to be stored in a safe way and must not be shared. A credential definition holds cryptographic material needed to verify proofs. Every definition is bound to one credential schema. Note that `options.identity` needs to be whitelisted for this function.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("create_credential_schema")
+                            .about("Creates a new zero-knowledge proof credential schema. Note that `options.identity` needs to be whitelisted for this function.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("create_revocation_registry_definition")
+                            .about("Creates a new revocation registry definition and stores it on-chain. The definition consists of a public and a private part. The public part holds the cryptographic material needed to create non-revocation proofs. The private part needs to reside with the registry owner and is used to revoke credentials. Note that `options.identity` needs to be whitelisted for this function.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("issue_credential")
+                            .about("Finishes a credential by incorporating the prover's master secret into the credential signature after issuance.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("finish_credential")
+                            .about("Issues a new credential. This requires an issued schema, credential definition, an active revocation registry and a credential request message.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("create_credential_offer")
+                            .about("Creates a `CredentialOffer` message. A `CredentialOffer` is sent by an issuer and is the response to a `CredentialProposal`. The `CredentialOffer` specifies which schema and definition the issuer is capable and willing to use for credential issuance.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("present_proof")
+                            .about("Presents a proof for one or more credentials. A proof presentation is the response to a proof request. The proof needs to incorporate all required fields from all required schemas requested in the proof request.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("create_credential_proposal")
+                            .about("Creates a new zero-knowledge proof credential proposal. This message is the first in the credential issuance flow and is sent by the potential credential holder to the credential issuer.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("request_credential")
+                            .about("Requests a credential. This message is the response to a credential offering and is sent by the potential credential holder. It incorporates the target schema, credential definition offered by the issuer, and the encoded values the holder wants to get signed. The credential is not stored on-chain and needs to be kept private.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("request_proof")
+                            .about("Requests a zero-knowledge proof for one or more credentials issued under one or more specific schemas and is sent by a verifier to a prover. The proof request consists of the fields the verifier wants to be revealed per schema.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("revoke_credential")
+                            .about("Revokes a credential. After revocation the published revocation registry needs to be updated with information returned by this function. To revoke a credential, tbe revoker must be in possession of the private key associated with the credential's revocation registry. After revocation, the published revocation registry must be updated. Only then is the credential truly revoked. Note that `options.identity` needs to be whitelisted for this function.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+                    .subcommand(
+                        SubCommand::with_name("verify_proof")
+                            .about("Verifies a one or multiple proofs sent in a proof presentation.")
+                            .arg(get_clap_argument("method")?)
+                            .arg(get_clap_argument("options")?)
+                            .arg(get_clap_argument("payload")?)
+                            .arg(get_clap_argument("target")?)
+                            .arg(get_clap_argument("signer")?),
+                    )
+            );
+        } else {
+        }
+    }
+
+    Ok(app)
+}
+
 fn get_app<'a>() -> Result<App<'a, 'a>, Box<dyn std::error::Error>> {
-    Ok(App::new("vade_evan_cli")
+    // variable might be needlessly mutable due to the following feature listing not matching
+    #[allow(unused_mut)]
+    let mut app = App::new("vade_evan_cli")
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
         .about("Allows you to use to work with DIDs and zero knowledge proof VCs")
         .setting(AppSettings::DeriveDisplayOrder)
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
-            SubCommand::with_name("did")
-                .about("Works with DIDs.")
-                .setting(AppSettings::DeriveDisplayOrder)
-                .setting(AppSettings::SubcommandRequiredElseHelp)
-                .subcommand(
-                    SubCommand::with_name("create")
-                        .about("Creates a new DID on substrate.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("resolve")
-                        .about("Fetch data about a DID, which returns this DID's DID document.")
-                        .arg(get_clap_argument("did")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("update")
-                        .about(r###"Updates data related to a DID. Two updates are supported depending on the value of `options.operation`.
-            - whitelistIdentity: whitelists identity `did` on substrate, this is required to be able to perform transactions this this identity
-            - setDidDocument: sets the DID document for `did`"###)
-                        .arg(get_clap_argument("did")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-        )
-        .subcommand(
-            SubCommand::with_name("didcomm")
-                .about("Processes DIDComm message")
-                .setting(AppSettings::DeriveDisplayOrder)
-                .setting(AppSettings::SubcommandRequiredElseHelp)
-                .subcommand(
-                    SubCommand::with_name("send")
-                        .about(r###"Prepare a plain DIDComm json message to be sent, including encryption and protocol specific message enhancement.
-The DIDComm options can include a shared secret to encrypt the message with a specific key.
-If no key was given and the message should be encrypted (depends on protocol implementation), the DIDComm keypair from a db provider will be used."###)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("receive")
-                        .about(r###"Receive a plain DIDComm json message, including decryption and protocol specific message parsing.
-The DIDComm options can include a shared secret to encrypt the message with a specific key.
-If no key was given and the message is encrypted the DIDComm keypair from a db will be used."###)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("create_keys")
-                        .about(r###"Create X25519 secret/public keys, which can be used in options while sending and receiving DIDComm message."###)
-                )
-                .subcommand(
-                    SubCommand::with_name("query_didcomm_messages")
-                        .about(r###"Query stored DIDComm messages by prefix (message_{thid}_*) or messageid (message_{thid}_{msgid})."###)
-                        .arg(get_clap_argument("payload")?),
-                )
-        )
-        .subcommand(
-            SubCommand::with_name("vc_zkp")
-                .about("Works with zero knowledge proof VCs.")
-                .setting(AppSettings::DeriveDisplayOrder)
-                .setting(AppSettings::SubcommandRequiredElseHelp)
-                .subcommand(
-                    SubCommand::with_name("create_master_secret")
-                        .about("Creates a new master secret.")
-                        .arg(get_clap_argument("options")?)
-                )
-                .subcommand(
-                    SubCommand::with_name("create_new_keys")
-                        .about("Creates a new key pair and stores it in the DID document.")
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("generate_safe_prime")
-                        .about("Generates a new safe prime number, that can be used in combination with `create_credential_definition` to for key pair generation.")
-                )
-                .subcommand(
-                    SubCommand::with_name("create_credential_definition")
-                        .about("Creates a new credential definition and stores the public part on-chain. The private part (key) needs to be stored in a safe way and must not be shared. A credential definition holds cryptographic material needed to verify proofs. Every definition is bound to one credential schema. Note that `options.identity` needs to be whitelisted for this function.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("create_credential_schema")
-                        .about("Creates a new zero-knowledge proof credential schema. Note that `options.identity` needs to be whitelisted for this function.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("create_revocation_registry_definition")
-                        .about("Creates a new revocation registry definition and stores it on-chain. The definition consists of a public and a private part. The public part holds the cryptographic material needed to create non-revocation proofs. The private part needs to reside with the registry owner and is used to revoke credentials. Note that `options.identity` needs to be whitelisted for this function.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("issue_credential")
-                        .about("Finishes a credential by incorporating the prover's master secret into the credential signature after issuance.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("finish_credential")
-                        .about("Issues a new credential. This requires an issued schema, credential definition, an active revocation registry and a credential request message.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("create_credential_offer")
-                        .about("Creates a `CredentialOffer` message. A `CredentialOffer` is sent by an issuer and is the response to a `CredentialProposal`. The `CredentialOffer` specifies which schema and definition the issuer is capable and willing to use for credential issuance.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("present_proof")
-                        .about("Presents a proof for one or more credentials. A proof presentation is the response to a proof request. The proof needs to incorporate all required fields from all required schemas requested in the proof request.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("create_credential_proposal")
-                        .about("Creates a new zero-knowledge proof credential proposal. This message is the first in the credential issuance flow and is sent by the potential credential holder to the credential issuer.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("request_credential")
-                        .about("Requests a credential. This message is the response to a credential offering and is sent by the potential credential holder. It incorporates the target schema, credential definition offered by the issuer, and the encoded values the holder wants to get signed. The credential is not stored on-chain and needs to be kept private.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("request_proof")
-                        .about("Requests a zero-knowledge proof for one or more credentials issued under one or more specific schemas and is sent by a verifier to a prover. The proof request consists of the fields the verifier wants to be revealed per schema.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("revoke_credential")
-                        .about("Revokes a credential. After revocation the published revocation registry needs to be updated with information returned by this function. To revoke a credential, tbe revoker must be in possession of the private key associated with the credential's revocation registry. After revocation, the published revocation registry must be updated. Only then is the credential truly revoked. Note that `options.identity` needs to be whitelisted for this function.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-                .subcommand(
-                    SubCommand::with_name("verify_proof")
-                        .about("Verifies a one or multiple proofs sent in a proof presentation.")
-                        .arg(get_clap_argument("method")?)
-                        .arg(get_clap_argument("options")?)
-                        .arg(get_clap_argument("payload")?)
-                        .arg(get_clap_argument("target")?)
-                        .arg(get_clap_argument("signer")?),
-                )
-        )
-        .subcommand(
             SubCommand::with_name("build_version")
                 .about("shows version of vade_evan_cli build and its vade dependencies")
-                .setting(AppSettings::DeriveDisplayOrder)
-        )
-    )
+                .setting(AppSettings::DeriveDisplayOrder),
+        );
+
+    app = add_subcommand_did(app)?;
+    app = add_subcommand_didcomm(app)?;
+    app = add_subcommand_vc_zkp(app)?;
+
+    Ok(app)
 }
 
 fn get_argument_matches<'a>() -> Result<ArgMatches<'a>, Box<dyn std::error::Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,9 +181,13 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+// not included in all build variants
+#[allow(dead_code)]
 fn add_subcommand_did<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
+    // variable might be needlessly mutable due to the following feature listing not matching
+    #[allow(unused_mut)]
     let mut subcommand = SubCommand::with_name("did")
-        .about("Works with DIDs.")
+        .about("Work with DIDs")
         .setting(AppSettings::DeriveDisplayOrder)
         .setting(AppSettings::SubcommandRequiredElseHelp);
 
@@ -203,7 +207,7 @@ fn add_subcommand_did<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         if #[cfg(feature = "capability-did-read")] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("create")
-                    .about("Creates a new DID on substrate.")
+                    .about("Creates a new DID.")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("target")?)
@@ -218,9 +222,7 @@ fn add_subcommand_did<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
             )
             .subcommand(
                 SubCommand::with_name("update")
-                    .about(r###"Updates data related to a DID. Two updates are supported depending on the value of `options.operation`.
-                - whitelistIdentity: whitelists identity `did` on substrate, this is required to be able to perform transactions this this identity
-                - setDidDocument: sets the DID document for `did`"###)
+                    .about(r###"Updates data related to a DID.`"###)
                     .arg(get_clap_argument("did")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)
@@ -233,45 +235,47 @@ fn add_subcommand_did<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     Ok(app.subcommand(subcommand))
 }
 
+// not included in all build variants
+#[allow(dead_code)]
 fn add_subcommand_didcomm<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     let app = app.subcommand(
-                SubCommand::with_name("didcomm")
-                    .about("Processes DIDComm message")
-                    .setting(AppSettings::DeriveDisplayOrder)
-                    .setting(AppSettings::SubcommandRequiredElseHelp)
-                    .subcommand(
-                        SubCommand::with_name("send")
-                            .about(r###"Prepare a plain DIDComm json message to be sent, including encryption and protocol specific message enhancement.
-        The DIDComm options can include a shared secret to encrypt the message with a specific key.
-        If no key was given and the message should be encrypted (depends on protocol implementation), the DIDComm keypair from a db provider will be used."###)
-                            .arg(get_clap_argument("options")?)
-                            .arg(get_clap_argument("payload")?),
-                    )
-                    .subcommand(
-                        SubCommand::with_name("receive")
-                            .about(r###"Receive a plain DIDComm json message, including decryption and protocol specific message parsing.
-        The DIDComm options can include a shared secret to encrypt the message with a specific key.
-        If no key was given and the message is encrypted the DIDComm keypair from a db will be used."###)
-                            .arg(get_clap_argument("options")?)
-                            .arg(get_clap_argument("payload")?),
-                    )
-                    .subcommand(
-                        SubCommand::with_name("create_keys")
-                            .about(r###"Create X25519 secret/public keys, which can be used in options while sending and receiving DIDComm message."###)
-                    )
-                    .subcommand(
-                        SubCommand::with_name("query_didcomm_messages")
-                            .about(r###"Query stored DIDComm messages by prefix (message_{thid}_*) or messageid (message_{thid}_{msgid})."###)
-                            .arg(get_clap_argument("payload")?),
-                    )
+        SubCommand::with_name("didcomm")
+            .about("Process DIDComm message")
+            .setting(AppSettings::DeriveDisplayOrder)
+            .setting(AppSettings::SubcommandRequiredElseHelp)
+            .subcommand(
+                SubCommand::with_name("send")
+                    .about(r###"Prepare a plain DIDComm json message to be sent, including encryption and protocol specific message enhancement. The DIDComm options can include a shared secret to encrypt the message with a specific key. If no key was given and the message should be encrypted (depends on protocol implementation), the DIDComm keypair from a db provider will be used."###)
+                    .arg(get_clap_argument("options")?)
+                    .arg(get_clap_argument("payload")?),
+            )
+            .subcommand(
+                SubCommand::with_name("receive")
+                    .about(r###"Receive a plain DIDComm json message, including decryption and protocol specific message parsing. The DIDComm options can include a shared secret to encrypt the message with a specific key. If no key was given and the message is encrypted the DIDComm keypair from a db will be used."###)
+                    .arg(get_clap_argument("options")?)
+                    .arg(get_clap_argument("payload")?),
+            )
+            .subcommand(
+                SubCommand::with_name("create_keys")
+                    .about(r###"Create X25519 secret/public keys, which can be used in options while sending and receiving DIDComm message."###)
+            )
+            .subcommand(
+                SubCommand::with_name("query_didcomm_messages")
+                    .about(r###"Query stored DIDComm messages by prefix (message_{thid}_*) or message id (message_{thid}_{msgid})."###)
+                    .arg(get_clap_argument("payload")?),
+            )
     );
 
     Ok(app)
 }
 
+// not included in all build variants
+#[allow(dead_code)]
 fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
+    // variable might be needlessly mutable due to the following feature listing not matching
+    #[allow(unused_mut)]
     let mut subcommand = SubCommand::with_name("vc_zkp")
-        .about("Work with zero knowledge proof VCs.")
+        .about("Work with zero knowledge proof VCs")
         .setting(AppSettings::DeriveDisplayOrder)
         .setting(AppSettings::SubcommandRequiredElseHelp);
 
@@ -460,7 +464,7 @@ fn get_app<'a>() -> Result<App<'a, 'a>> {
     let mut app = App::new("vade_evan_cli")
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
-        .about("Allows to work with DID's and zero knowledge proof VC's")
+        .about("Allows to work with DIDs and zero knowledge proof VCs")
         .setting(AppSettings::DeriveDisplayOrder)
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(

--- a/src/main.rs
+++ b/src/main.rs
@@ -271,7 +271,7 @@ fn add_subcommand_didcomm<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
 
 fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     let mut subcommand = SubCommand::with_name("vc_zkp")
-        .about("Works with zero knowledge proof VCs.")
+        .about("Work with zero knowledge proof VCs.")
         .setting(AppSettings::DeriveDisplayOrder)
         .setting(AppSettings::SubcommandRequiredElseHelp);
 
@@ -279,7 +279,7 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         if #[cfg(feature = "plugin-vc-zkp-bbs")] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("create_credential_schema")
-                    .about("Creates a new zero-knowledge proof credential schema. Note that `options.identity` needs to be whitelisted for this function.")
+                    .about("Creates a new zero-knowledge proof credential schema.")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)
@@ -303,7 +303,7 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         if #[cfg(feature = "plugin-vc-zkp-bbs")] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("create_revocation_registry_definition")
-                    .about("Creates a new revocation registry definition and stores it on-chain. The definition consists of a public and a private part. The public part holds the cryptographic material needed to create non-revocation proofs. The private part needs to reside with the registry owner and is used to revoke credentials. Note that `options.identity` needs to be whitelisted for this function.")
+                    .about("Creates a new revocation registry definition and stores it on-chain. The definition consists of a public and a private part. The public part holds the cryptographic material needed to create non-revocation proofs. The private part needs to reside with the registry owner and is used to revoke credentials")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)
@@ -329,7 +329,7 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         if #[cfg(any(feature = "plugin-vc-zkp-bbs", feature = "plugin-jwt-vct"))] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("issue_credential")
-                    .about("Finishes a credential by incorporating the prover's master secret into the credential signature after issuance.")
+                    .about("Issues a new credential.")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)
@@ -343,7 +343,7 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         if #[cfg(feature = "plugin-vc-zkp-bbs")] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("finish_credential")
-                    .about("Issues a new credential. This requires an issued schema, credential definition, an active revocation registry and a credential request message.")
+                    .about("Finishes a credential by incorporating the prover's master secret into the credential signature after issuance.")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)
@@ -357,7 +357,7 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         if #[cfg(feature = "plugin-vc-zkp-bbs")] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("create_credential_offer")
-                    .about("Creates a `CredentialOffer` message. A `CredentialOffer` is sent by an issuer and is the response to a `CredentialProposal`. The `CredentialOffer` specifies which schema and definition the issuer is capable and willing to use for credential issuance.")
+                    .about("Creates a `CredentialOffer` message. A `CredentialOffer` is sent by an issuer and is the response to a `CredentialProposal`. The `CredentialOffer` specifies which schema the issuer is capable and willing to use for credential issuance.")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)
@@ -399,7 +399,7 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         if #[cfg(feature = "plugin-vc-zkp-bbs")] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("request_credential")
-                    .about("Requests a credential. This message is the response to a credential offering and is sent by the potential credential holder. It incorporates the target schema, credential definition offered by the issuer, and the encoded values the holder wants to get signed. The credential is not stored on-chain and needs to be kept private.")
+                    .about("Requests a credential. This message is the response to a credential offering and is sent by the potential credential holder. It incorporates the target schema offered by the issuer, and the encoded values the holder wants to get signed. The credential is not stored on-chain and needs to be kept private.")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)
@@ -427,7 +427,7 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         if #[cfg(feature = "plugin-vc-zkp-bbs")] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("revoke_credential")
-                    .about("Revokes a credential. After revocation the published revocation registry needs to be updated with information returned by this function. To revoke a credential, tbe revoker must be in possession of the private key associated with the credential's revocation registry. After revocation, the published revocation registry must be updated. Only then is the credential truly revoked. Note that `options.identity` needs to be whitelisted for this function.")
+                    .about("Revokes a credential. After revocation the published revocation registry needs to be updated with information returned by this function. To revoke a credential, tbe revoker must be in possession of the private key associated with the credential's revocation registry. After revocation, the published revocation registry must be updated. Only then is the credential truly revoked.")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)
@@ -460,7 +460,7 @@ fn get_app<'a>() -> Result<App<'a, 'a>> {
     let mut app = App::new("vade_evan_cli")
         .version(env!("CARGO_PKG_VERSION"))
         .author(env!("CARGO_PKG_AUTHORS"))
-        .about("Allows you to use to work with DIDs and zero knowledge proof VCs")
+        .about("Allows to work with DID's and zero knowledge proof VC's")
         .setting(AppSettings::DeriveDisplayOrder)
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(
@@ -523,14 +523,14 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
             .short("d")
             .value_name("did")
             .required(true)
-            .help("a DID to work on, e.g. 'did:evan:testcore:0x0d87204c3957d73b68ae28d0af961d3c72403906'")
+            .help("a DID to work with, e.g. 'did:evan:testcore:0x0d87204c3957d73b68ae28d0af961d3c72403906'")
             .takes_value(true),
         "method" => Arg::with_name("method")
             .long("method")
             .short("m")
             .value_name("method")
             .required(true)
-            .help("method to work on, e.g. 'did:evan'")
+            .help("method to use, e.g. 'did:evan'")
             .takes_value(true),
         "options" => Arg::with_name("options")
             .long("options")
@@ -544,13 +544,13 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
             .short("p")
             .value_name("payload")
             .required(true)
-            .help("options to send to vade call, serialized JSON, e.g. '{ \"foo\": \"bar\" }'")
+            .help("payload to send to vade call, serialized JSON, e.g. '{ \"foo\": \"bar\" }'")
             .takes_value(true),
         "target" => Arg::with_name("target")
             .long("target")
             .short("t")
             .value_name("target")
-            .help("substrate to use for DID handling, e.g. '127.0.0.1'")
+            .help("server to use for DID handling, e.g. '127.0.0.1'")
             .takes_value(true),
         "signer" => Arg::with_name("signer")
             .long("signer")

--- a/src/main.rs
+++ b/src/main.rs
@@ -282,6 +282,28 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "plugin-vc-zkp-bbs")] {
             subcommand = subcommand.subcommand(
+                SubCommand::with_name("create_master_secret")
+                    .about("Creates a new master secret.")
+                    .arg(get_clap_argument("options")?)
+            );
+        } else {}
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "plugin-vc-zkp-bbs")] {
+            subcommand = subcommand.subcommand(
+                SubCommand::with_name("create_new_keys")
+                    .about("Creates a new key pair and stores it in the DID document.")
+                    .arg(get_clap_argument("options")?)
+                    .arg(get_clap_argument("payload")?)
+                    .arg(get_clap_argument("signer")?),
+            );
+        } else {}
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "plugin-vc-zkp-bbs")] {
+            subcommand = subcommand.subcommand(
                 SubCommand::with_name("create_credential_schema")
                     .about("Creates a new zero-knowledge proof credential schema.")
                     .arg(get_clap_argument("method")?)
@@ -296,34 +318,12 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "plugin-vc-zkp-bbs")] {
             subcommand = subcommand.subcommand(
-                SubCommand::with_name("create_master_secret")
-                    .about("Creates a new master secret.")
-                    .arg(get_clap_argument("options")?)
-            );
-        } else {}
-    }
-
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "plugin-vc-zkp-bbs")] {
-            subcommand = subcommand.subcommand(
                 SubCommand::with_name("create_revocation_registry_definition")
                     .about("Creates a new revocation registry definition and stores it on-chain. The definition consists of a public and a private part. The public part holds the cryptographic material needed to create non-revocation proofs. The private part needs to reside with the registry owner and is used to revoke credentials")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)
                     .arg(get_clap_argument("target")?)
-                    .arg(get_clap_argument("signer")?),
-            );
-        } else {}
-    }
-
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "plugin-vc-zkp-bbs")] {
-            subcommand = subcommand.subcommand(
-                SubCommand::with_name("create_new_keys")
-                    .about("Creates a new key pair and stores it in the DID document.")
-                    .arg(get_clap_argument("options")?)
-                    .arg(get_clap_argument("payload")?)
                     .arg(get_clap_argument("signer")?),
             );
         } else {}

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -89,14 +89,14 @@ pub fn set_log_level(log_level: String) {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "did-read")] {
+    if #[cfg(feature = "capability-did-read")] {
         create_function!(did_resolve, did_or_method, config);
     } else {
     }
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "did-write")] {
+    if #[cfg(feature = "capability-did-write")] {
         create_function!(did_create, did_or_method, options, payload, config);
         create_function!(did_update, did_or_method, options, payload, config);
     } else {
@@ -104,7 +104,7 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(feature = "didcomm")] {
+    if #[cfg(feature = "capability-didcomm")] {
         create_function!(didcomm_receive, options, payload, config);
         create_function!(didcomm_send, options, payload, config);
     } else {
@@ -112,35 +112,32 @@ cfg_if::cfg_if! {
 }
 
 cfg_if::cfg_if! {
-    if #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs", feature = "vc-jwt"))] {
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+    if #[cfg(feature = "capability-vc-zkp")] {
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(run_custom_function, did_or_method, custom_func_name, options, payload, config);
-        #[cfg(feature = "vc-zkp-cl")]
-        create_function!(vc_zkp_create_credential_definition, did_or_method, options, payload, config);
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_create_credential_offer, did_or_method, options, payload, config);
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_create_credential_proposal, did_or_method, options, payload, config);
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_create_credential_schema, did_or_method, options, payload, config);
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_create_revocation_registry_definition, did_or_method, options, payload, config);
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_update_revocation_registry, did_or_method, options, payload, config);
-
+        #[cfg(any(feature = "plugin-vc-zkp-bbs", feature = "plugin-jwt-vc"))]
         create_function!(vc_zkp_issue_credential, did_or_method, options, payload, config);
-
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_finish_credential, did_or_method, options, payload, config);
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_present_proof, did_or_method, options, payload, config);
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_request_credential, did_or_method, options, payload, config);
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_request_proof, did_or_method, options, payload, config);
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         create_function!(vc_zkp_revoke_credential, did_or_method, options, payload, config);
-
+        #[cfg(any(feature = "plugin-vc-zkp-bbs", feature = "plugin-jwt-vc"))]
         create_function!(vc_zkp_verify_proof, did_or_method, options, payload, config);
 
         #[wasm_bindgen]
@@ -238,61 +235,60 @@ pub async fn execute_vade(
     config: JsValue,
 ) -> String {
     let result = match func_name.as_str() {
-        #[cfg(feature = "did-read")]
+        #[cfg(feature = "capability-did-read")]
         "did_resolve" =>
             did_resolve(did_or_method, config).await,
-        #[cfg(feature = "did-write")]
+        #[cfg(feature = "capability-did-write")]
         "did_create" =>
             did_create(did_or_method, options, payload, config).await,
-        #[cfg(feature = "did-write")]
+        #[cfg(feature = "capability-did-write")]
         "did_update" =>
             did_update(did_or_method, options, payload, config).await,
-        #[cfg(feature = "didcomm")]
+
+        #[cfg(feature = "capability-didcomm")]
         "didcomm_receive" =>
             didcomm_receive(options, payload, config).await,
-        #[cfg(feature = "didcomm")]
+        #[cfg(feature = "capability-didcomm")]
         "didcomm_send" =>
             didcomm_send(options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "run_custom_function" =>
             run_custom_function(did_or_method, custom_func_name, options, payload, config).await,
-        #[cfg(feature = "vc-zkp-cl")]
-        "vc_zkp_create_credential_definition" =>
-            vc_zkp_create_credential_definition(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_create_credential_offer" =>
             vc_zkp_create_credential_offer(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_create_credential_proposal" =>
             vc_zkp_create_credential_proposal(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_create_credential_schema" =>
             vc_zkp_create_credential_schema(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_create_revocation_registry_definition" =>
             vc_zkp_create_revocation_registry_definition(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_update_revocation_registry" =>
             vc_zkp_update_revocation_registry(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs", feature = "vc-jwt"))]
+        #[cfg(any(feature = "vc-zkp-bbs", feature = "vc-jwt"))]
         "vc_zkp_issue_credential" =>
             vc_zkp_issue_credential(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_finish_credential" =>
             vc_zkp_finish_credential(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_present_proof" =>
             vc_zkp_present_proof(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_request_credential" =>
             vc_zkp_request_credential(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_request_proof" =>
             vc_zkp_request_proof(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs"))]
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
         "vc_zkp_revoke_credential" =>
             vc_zkp_revoke_credential(did_or_method, options, payload, config).await,
-        #[cfg(any(feature = "vc-zkp-cl", feature = "vc-zkp-bbs", feature = "vc-jwt"))]
+        #[cfg(any(feature = "vc-zkp-bbs", feature = "vc-jwt"))]
         "vc_zkp_verify_proof" =>
             vc_zkp_verify_proof(did_or_method, options, payload, config).await,
         _ => {


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Restructures feature setup to have a nomenclature that makes it easier to build `vade-evan` for different targets with different functionalities.

## Details

<!--- HOW does it change stuff? -->

- introduce new naming schema for features
  - `bundle-` features decide which (`VadePlugin`) plugins to include
  - `target-` features decide which build target (CLI, WASM, etc.) to build for
  - `plugin-` feature take care, that plugins and related dependencies are present
  - `capability-` features control which functionalities a `plugin-` may offer

## Impact on other parties

<!-- Delete points, that do not apply. Add comments to those that apply. -->
- existing build script will not work as before, as features have been renamed (except for running with default feature setup)