### PR TITLE
EI-390 Implement credential helper create-self-issued-credential draft

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5213,6 +5213,7 @@ dependencies = [
  "base64 0.13.1",
  "bbs",
  "cfg-if 0.1.10",
+ "chrono",
  "clap",
  "console_error_panic_hook",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.53", features = ["preserve_order", "raw_value"] }
 thiserror = "1.0.38"
 vade = "0.1.0"
+chrono = "0.4.23"
 
 ###################################################################### feature specific dependencies
 # plugin-did-sidetree

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -12,6 +12,7 @@
 - add `helper_verify_credential` helper function
 - add `helper_did_create` and `helper_did_update` functions
 - add `helper_revoke_credential` function
+- add `helper_create_self_issued_credential` helper function
 
 ### Fixes
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -506,28 +506,22 @@ impl VadeEvan {
     ///         use anyhow::Result;
     ///         use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
     ///
-    ///         const ISSUER_DID: &str = "did:evan:testcore:0x6240cedfc840579b7fdcd686bdc65a9a8c42dea6";
     ///         const SCHEMA_DID: &str = "did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw";
-    ///         const SUBJECT_DID: &str = "did:evan:testcore:0x67ce8b01b3b75a9ba4a1462139a1edaa0d2f539f";
-    ///         const ISSUER_PUBLIC_KEY: &str = "pubkey";
+    ///         const CREDENTIAL_SUBJECT_STR: &str = "{\"id\":\"did:evan:testcore:0x67ce8b01b3b75a9ba4a1462139a1edaa0d2f539f\", \"data\":{\"test\":\"value\"}";
     ///         const BBS_SECRET: &str = "bbssecret";
     ///         const BBS_PRIVATE_KEY: &str = "bbsprivkey";
-    ///         const CRED_VALUES: &str = "{\"test\":\"value\"}";
     ///
     ///         async fn example() -> Result<()> {
     ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
     ///             let offer_str = vade_evan
     ///                 .helper_create_self_issued_credential(
     ///                     SCHEMA_DID,
-    ///                     ISSUER_DID,
-    ///                     SUBJECT_DID,
-    ///                     ISSUER_PUBLIC_KEY,
+    ///                     CREDENTIAL_SUBJECT_STR,
     ///                     BBS_SECRET,
     ///                     BBS_PRIVATE_KEY,
-    ///                     CRED_VALUES,
-    ///                     Some(),
-    ///                     Some(),
-    ///                     Some(),
+    ///                     Some(""),
+    ///                     Some(""),
+    ///                     Some(""),
     ///                 )
     ///                 .await?;
     ///
@@ -542,20 +536,16 @@ impl VadeEvan {
     pub async fn helper_create_self_issued_credential(
         &mut self,
         schema_did: &str,
-        issuer_did: &str,
-        subject_did: &str,
-        issuer_public_key: &str,
+        credential_subject_str: &str,
         bbs_secret: &str,
         bbs_private_key: &str,
-        credential_values: &str,
         credential_revocation_did: Option<&str>,
         credential_revocation_id: Option<&str>,
         exp_date: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         let mut credential = Credential::new(self)?;
         credential
-            .create_self_issued_credential(schema_did, issuer_did, subject_did, issuer_public_key,
-                                           bbs_secret, bbs_private_key, credential_values,
+            .create_self_issued_credential(schema_did, credential_subject_str, bbs_secret, bbs_private_key,
                                            credential_revocation_did, credential_revocation_id, exp_date )
             .await
             .map_err(|err| err.into())
@@ -1155,7 +1145,7 @@ impl VadeEvan {
     ///         let bbs_public_key =  "LwDjc3acetrEsbccFI4zSy1+AFqUbkEUf6Sm0OxIdhU=";
     ///         let signing_key = None;
     ///         let service_url = "www.example.service";
-    ///      
+    ///
     ///         let create_response = vade_evan
     ///            .helper_did_create(
     ///                Some(bbs_public_key),
@@ -1197,7 +1187,7 @@ impl VadeEvan {
     /// ```
     /// cfg_if::cfg_if! {
     /// if #[cfg(not(all(feature = "target-c-lib", feature = "capability-sdk")))] {
-    /// 
+    ///
     ///     use anyhow::Result;
     ///     use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
     ///

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -618,8 +618,8 @@ impl VadeEvan {
     ///                     CREDENTIAL_SUBJECT_STR,
     ///                     BBS_SECRET,
     ///                     BBS_PRIVATE_KEY,
-    ///                     None,
-    ///                     None,
+    ///                     "did:revoc:12345",
+    ///                     "1",
     ///                     None,
     ///                 )
     ///                 .await?;

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -638,8 +638,8 @@ impl VadeEvan {
         credential_subject_str: &str,
         bbs_secret: &str,
         bbs_private_key: &str,
-        credential_revocation_did: Option<&str>,
-        credential_revocation_id: Option<&str>,
+        credential_revocation_did: &str,
+        credential_revocation_id: &str,
         exp_date: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         let mut credential = Credential::new(self)?;

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -493,8 +493,12 @@ impl VadeEvan {
     /// # Arguments
     ///
     /// * `schema_did` - schema to create the credential
-    /// * `issuer_did` - DID of issuer
-    /// * `subject_did` - DID of subject
+    /// * `credential_subject_str` - JSON string of CredentialSubject structure
+    /// * `bbs_secret` - BBS secret
+    /// * `bbs_private_key` - BBS private key
+    /// * `credential_revocation_did` - revocation list DID (or `None` if no revocation is used)
+    /// * `credential_revocation_id` - index in revocation list (or `None` if no revocation is used)
+    /// * `exp_date` - expiration date, string, e.g. "1722-12-03T14:23:42.120Z" (or `None` if no expiration date is used)
     ///
     /// # Returns
     /// * credential as JSON serialized [`BbsCredential`](https://docs.rs/vade_evan_bbs/*/vade_evan_bbs/struct.BbsCredential.html)
@@ -507,9 +511,14 @@ impl VadeEvan {
     ///         use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
     ///
     ///         const SCHEMA_DID: &str = "did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw";
-    ///         const CREDENTIAL_SUBJECT_STR: &str = "{\"id\":\"did:evan:testcore:0x67ce8b01b3b75a9ba4a1462139a1edaa0d2f539f\", \"data\":{\"test\":\"value\"}";
-    ///         const BBS_SECRET: &str = "bbssecret";
-    ///         const BBS_PRIVATE_KEY: &str = "bbsprivkey";
+    ///         const CREDENTIAL_SUBJECT_STR: &str = r#"{
+    ///                                                  "id":"did:evan:EiAOD3RUcQrRXNZIR8BIEXuGvixcUj667_5fdeX-Sp3PpA",
+    ///                                                  "data":{
+    ///                                                           "email":"value@x.com"
+    ///                                                         }
+    ///                                                }"#;
+    ///         const BBS_SECRET: &str = "GRsdzRB0pf/8MKP/ZBOM2BEV1A8DIDfmLh8T3b1hPKc=";
+    ///         const BBS_PRIVATE_KEY: &str = "WWTZW8pkz35UnvsUCEsof2CJmNHaJQ/X+B5xjWcHr/I=";
     ///
     ///         async fn example() -> Result<()> {
     ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
@@ -519,9 +528,9 @@ impl VadeEvan {
     ///                     CREDENTIAL_SUBJECT_STR,
     ///                     BBS_SECRET,
     ///                     BBS_PRIVATE_KEY,
-    ///                     Some(""),
-    ///                     Some(""),
-    ///                     Some(""),
+    ///                     None,
+    ///                     None,
+    ///                     None,
     ///                 )
     ///                 .await?;
     ///

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -18,7 +18,7 @@
 use std::os::raw::c_void;
 use vade::Vade;
 
-#[cfg(feature = "plugin-vc-zkp-bbs")]
+#[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
 use crate::helpers::Credential;
 #[cfg(feature = "plugin-did-sidetree")]
 use crate::helpers::Did;
@@ -318,7 +318,7 @@ impl VadeEvan {
     ///     }
     /// }
     /// ```
-    #[cfg(feature = "plugin-vc-zkp-bbs")]
+    #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
     pub async fn helper_create_credential_offer(
         &mut self,
         schema_did: &str,
@@ -382,7 +382,7 @@ impl VadeEvan {
     ///     }
     /// }
     /// ```
-    #[cfg(feature = "plugin-vc-zkp-bbs")]
+    #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
     pub async fn helper_create_credential_request(
         &mut self,
         issuer_public_key: &str,
@@ -473,7 +473,7 @@ impl VadeEvan {
     ///         // currently no example for capability-sdk and target-c-lib/target-java-lib
     ///     }
     /// }
-    #[cfg(feature = "plugin-vc-zkp-bbs")]
+    #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
     pub async fn helper_verify_credential(
         &mut self,
         credential: &str,
@@ -631,7 +631,7 @@ impl VadeEvan {
     ///     }
     /// }
     /// ```
-    #[cfg(feature = "plugin-vc-zkp-bbs")]
+    #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
     pub async fn helper_create_self_issued_credential(
         &mut self,
         schema_did: &str,
@@ -644,8 +644,15 @@ impl VadeEvan {
     ) -> Result<String, VadeEvanError> {
         let mut credential = Credential::new(self)?;
         credential
-            .create_self_issued_credential(schema_did, credential_subject_str, bbs_secret, bbs_private_key,
-                                           credential_revocation_did, credential_revocation_id, exp_date )
+            .create_self_issued_credential(
+                schema_did,
+                credential_subject_str,
+                bbs_secret,
+                bbs_private_key,
+                credential_revocation_did,
+                credential_revocation_id,
+                exp_date,
+            )
             .await
             .map_err(|err| err.into())
     }

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -484,6 +484,81 @@ impl VadeEvan {
             .map_err(|err| err.into())
     }
 
+    /// Creates a new zero-knowledge proof self issued credential.
+    /// `create_self_issued_credential` function can be used in the same step
+    /// and produces the same output as `vc_zkp_create_credential_offer` but uses a simpler argument setup.
+    ///
+    /// # Arguments
+    ///
+    /// * `schema_did` - schema to create the credential
+    /// * `issuer_did` - DID of issuer
+    /// * `subject_did` - DID of subject
+    ///
+    /// # Returns
+    /// * credential as JSON serialized [`BbsCredential`](https://docs.rs/vade_evan_bbs/*/vade_evan_bbs/struct.BbsCredential.html)
+    /// # Example
+    ///
+    /// ```
+    /// cfg_if::cfg_if! {
+    ///     if #[cfg(not(all(feature = "target-c-lib", feature = "capability-sdk")))] {
+    ///         use anyhow::Result;
+    ///         use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
+    ///
+    ///         const ISSUER_DID: &str = "did:evan:testcore:0x6240cedfc840579b7fdcd686bdc65a9a8c42dea6";
+    ///         const SCHEMA_DID: &str = "did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw";
+    ///         const SUBJECT_DID: &str = "did:evan:testcore:0x67ce8b01b3b75a9ba4a1462139a1edaa0d2f539f";
+    ///         const ISSUER_PUBLIC_KEY: &str = "pubkey";
+    ///         const BBS_SECRET: &str = "bbssecret";
+    ///         const BBS_PRIVATE_KEY: &str = "bbsprivkey";
+    ///         const CRED_VALUES: &str = "{\"test\":\"value\"}";
+    ///
+    ///         async fn example() -> Result<()> {
+    ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
+    ///             let offer_str = vade_evan
+    ///                 .helper_create_self_issued_credential(
+    ///                     SCHEMA_DID,
+    ///                     ISSUER_DID,
+    ///                     SUBJECT_DID,
+    ///                     ISSUER_PUBLIC_KEY,
+    ///                     BBS_SECRET,
+    ///                     BBS_PRIVATE_KEY,
+    ///                     CRED_VALUES,
+    ///                     Some(),
+    ///                     Some(),
+    ///                     Some(),
+    ///                 )
+    ///                 .await?;
+    ///
+    ///             Ok(())
+    ///         }
+    ///     } else {
+    ///         // currently no example for capability-sdk and target-c-lib/target-java-lib
+    ///     }
+    /// }
+    /// ```
+    #[cfg(feature = "plugin-vc-zkp-bbs")]
+    pub async fn helper_create_self_issued_credential(
+        &mut self,
+        schema_did: &str,
+        issuer_did: &str,
+        subject_did: &str,
+        issuer_public_key: &str,
+        bbs_secret: &str,
+        bbs_private_key: &str,
+        credential_values: &str,
+        credential_revocation_did: Option<&str>,
+        credential_revocation_id: Option<&str>,
+        exp_date: Option<&str>,
+    ) -> Result<String, VadeEvanError> {
+        let mut credential = Credential::new(self)?;
+        credential
+            .create_self_issued_credential(schema_did, issuer_did, subject_did, issuer_public_key,
+                                           bbs_secret, bbs_private_key, credential_values,
+                                           credential_revocation_did, credential_revocation_id, exp_date )
+            .await
+            .map_err(|err| err.into())
+    }
+
     /// Runs a custom function, this allows to use `Vade`s API for custom calls, that do not belong
     /// to `Vade`s core functionality but may be required for a projects use cases.
     ///

--- a/src/api/vade_evan_error.rs
+++ b/src/api/vade_evan_error.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "plugin-vc-zkp-bbs")]
+#[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
 use crate::helpers::CredentialError;
 use thiserror::Error;
 
@@ -10,7 +10,7 @@ pub enum VadeEvanError {
     InternalError { source_message: String },
     #[error("vade call returned no results")]
     NoResults,
-    #[cfg(feature = "plugin-vc-zkp-bbs")]
+    #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
     #[error(transparent)]
     CredentialError(#[from] CredentialError),
 }

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -629,8 +629,8 @@ pub extern "C" fn execute_vade(
                         arguments_vec.get(1).unwrap_or_else(|| &no_args),
                         arguments_vec.get(2).unwrap_or_else(|| &no_args),
                         arguments_vec.get(3).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(4).map(|v| v.as_str()),
-                        arguments_vec.get(5).map(|v| v.as_str()),
+                        arguments_vec.get(4).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(5).unwrap_or_else(|| &no_args),
                         arguments_vec.get(6).map(|v| v.as_str()),
                     )
                     .await

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -610,12 +610,9 @@ pub extern "C" fn execute_vade(
                         arguments_vec.get(1).unwrap_or_else(|| &no_args),
                         arguments_vec.get(2).unwrap_or_else(|| &no_args),
                         arguments_vec.get(3).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(4).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(5).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(6).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(7).map(|v| v.as_str()),
-                        arguments_vec.get(8).map(|v| v.as_str()),
-                        arguments_vec.get(9).map(|v| v.as_str()),
+                        arguments_vec.get(4).map(|v| v.as_str()),
+                        arguments_vec.get(5).map(|v| v.as_str()),
+                        arguments_vec.get(6).map(|v| v.as_str()),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -519,7 +519,7 @@ pub extern "C" fn execute_vade(
                 request_function_callback
             )
         }),
-        #[cfg(feature = "plugin-vc-zkp-bbs")]
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
         "helper_create_credential_offer" => runtime.block_on({
             async {
                 let mut vade_evan = get_vade_evan(
@@ -545,7 +545,7 @@ pub extern "C" fn execute_vade(
                     .map_err(stringify_vade_evan_error)
             }
         }),
-        #[cfg(feature = "plugin-vc-zkp-bbs")]
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
         "helper_create_credential_request" => runtime.block_on({
             async {
                 let mut vade_evan = get_vade_evan(
@@ -568,7 +568,7 @@ pub extern "C" fn execute_vade(
                     .map_err(stringify_vade_evan_error)
             }
         }),
-        #[cfg(feature = "plugin-vc-zkp-bbs")]
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
         "helper_verify_credential" => runtime.block_on({
             async {
                 let mut vade_evan = get_vade_evan(
@@ -612,17 +612,17 @@ pub extern "C" fn execute_vade(
                 Ok("".to_string())
             }
         }),
-        #[cfg(feature = "plugin-vc-zkp-bbs")]
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
         "helper_create_self_issued_credential" => runtime.block_on({
             async {
                 let mut vade_evan = get_vade_evan(
                     Some(&str_config),
                     #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
-                        ptr_request_list,
+                    ptr_request_list,
                     #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
-                        request_function_callback,
+                    request_function_callback,
                 )
-                    .map_err(stringify_generic_error)?;
+                .map_err(stringify_generic_error)?;
                 vade_evan
                     .helper_create_self_issued_credential(
                         arguments_vec.get(0).unwrap_or_else(|| &no_args),

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -600,10 +600,6 @@ pub extern "C" fn execute_vade(
                         request_function_callback,
                 )
                     .map_err(stringify_generic_error)?;
-                let use_valid_until = match arguments_vec.get(1) {
-                    Some(value) => value.to_lowercase() == "true",
-                    None => false,
-                };
                 vade_evan
                     .helper_create_self_issued_credential(
                         arguments_vec.get(0).unwrap_or_else(|| &no_args),

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -546,6 +546,38 @@ pub extern "C" fn execute_vade(
                 Ok("".to_string())
             }
         }),
+        #[cfg(feature = "plugin-vc-zkp-bbs")]
+        "helper_create_self_issued_credential" => runtime.block_on({
+            async {
+                let mut vade_evan = get_vade_evan(
+                    Some(&str_config),
+                    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+                        ptr_request_list,
+                    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+                        request_function_callback,
+                )
+                    .map_err(stringify_generic_error)?;
+                let use_valid_until = match arguments_vec.get(1) {
+                    Some(value) => value.to_lowercase() == "true",
+                    None => false,
+                };
+                vade_evan
+                    .helper_create_self_issued_credential(
+                        arguments_vec.get(0).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(1).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(2).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(3).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(4).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(5).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(6).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(7).map(|v| v.as_str()),
+                        arguments_vec.get(8).map(|v| v.as_str()),
+                        arguments_vec.get(9).map(|v| v.as_str()),
+                    )
+                    .await
+                    .map_err(stringify_vade_evan_error)
+            }
+        }),
         #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "run_custom_function" => runtime.block_on({
             execute_vade_function!(

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -294,7 +294,6 @@ impl<'a> Credential<'a> {
             .get_issuer_public_key(&subject_did, "#bbs-key-1")
             .await?;
         let use_valid_until= if exp_date.is_some() { true } else { false };
-        let exp_date_str = exp_date.unwrap_or("");
         let credential_values_str = serde_json::to_string(&credential_subject.clone().data)?;
 
 
@@ -308,7 +307,7 @@ impl<'a> Credential<'a> {
         let r#type = vec!["VerifiableCredential".to_string()];
         let issuer = subject_did.clone();
         let valid_until = if use_valid_until {
-            Some(exp_date_str.to_string())
+            Some(exp_date.unwrap_or("").to_string())
         } else {
             None
         };

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -890,13 +890,13 @@ mod tests {
             signer: "remote|http://127.0.0.1:7070/key/sign",
         })?;
         let credential_subject_str = r#"{
-            "id": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
+            "id": "did:evan:EiAOD3RUcQrRXNZIR8BIEXuGvixcUj667_5fdeX-Sp3PpA",
             "data": {
                 "email": "value@x.com"
             }
         }"#;
-        let bbs_secret = r#"OASkVMA8q6b3qJuabvgaN9K1mKoqptCv4SCNvRmnWuI="#;
-        let bbs_private_key = r#"OASkVMA8q6b3qJuabvgaN9K1mKoqptCv4SCNvRmnWuI="#;
+        let bbs_secret = r#"GRsdzRB0pf/8MKP/ZBOM2BEV1A8DIDfmLh8T3b1hPKc="#;
+        let bbs_private_key = r#"WWTZW8pkz35UnvsUCEsof2CJmNHaJQ/X+B5xjWcHr/I="#;
         let schema_did = r#"did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw"#;
 
         let credential = vade_evan
@@ -910,7 +910,8 @@ mod tests {
                 None,
             ) .await?;
 
-        assert!(credential.contains("did"));
+        assert!(credential.contains(r##"type":["VerifiableCredential"],"issuer":"did:evan:EiAOD3RUcQrRXNZIR8BIEXuGvixcUj667_5fdeX-Sp3PpA"##));
+        assert!(credential.contains(r##"credentialSubject":{"id":"did:evan:EiAOD3RUcQrRXNZIR8BIEXuGvixcUj667_5fdeX-Sp3PpA","data":{"email":""}},"credentialSchema":{"id":"did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw","type":"EvanVCSchema"},"credentialStatus":{"id":"did:evan:zkp:placeholder_status#0","type":"RevocationList2020Status","revocationListIndex":"0","revocationListCredential":"did:evan:zkp:placeholder_status"},"proof":{"type":"BbsBlsSignature2020"##));
 
         Ok(())
     }

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -329,8 +329,8 @@ impl<'a> Credential<'a> {
             id: schema.id,
             r#type: schema.r#type,
         };
-        let revocation_list_index = credential_revocation_id.unwrap_or(r#"0"#).to_string();
-        let revocation_list_credential = credential_revocation_did.unwrap_or(r#"did:evan:zkp:placeholder_status"#).to_string();
+        let revocation_list_index = credential_revocation_id.unwrap_or("0").to_string();
+        let revocation_list_credential = credential_revocation_did.unwrap_or("did:evan:zkp:placeholder_status").to_string();
         let status_id = [revocation_list_credential.clone(), revocation_list_index.clone()].join("#");
         let credential_status = CredentialStatus {
             id: status_id,
@@ -384,7 +384,7 @@ impl<'a> Credential<'a> {
         let pload = IssueCredentialPayload {
             unsigned_vc: unsigned_credential,
             nquads: nquads_vc,
-            issuer_public_key_id: r##"#bbs-key-1"##.to_string(),
+            issuer_public_key_id: "#bbs-key-1".to_string(),
             issuer_public_key: issuer_public_key.clone(),
             issuer_secret_key: bbs_private_key.to_string(),
             credential_request: request.clone(),
@@ -897,9 +897,9 @@ mod tests {
                 "email": "value@x.com"
             }
         }"#;
-        let bbs_secret = r#"GRsdzRB0pf/8MKP/ZBOM2BEV1A8DIDfmLh8T3b1hPKc="#;
-        let bbs_private_key = r#"WWTZW8pkz35UnvsUCEsof2CJmNHaJQ/X+B5xjWcHr/I="#;
-        let schema_did = r#"did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw"#;
+        let bbs_secret = "GRsdzRB0pf/8MKP/ZBOM2BEV1A8DIDfmLh8T3b1hPKc=";
+        let bbs_private_key = "WWTZW8pkz35UnvsUCEsof2CJmNHaJQ/X+B5xjWcHr/I=";
+        let schema_did = "did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw";
 
         let credential = vade_evan
             .helper_create_self_issued_credential(
@@ -912,7 +912,7 @@ mod tests {
                 None,
             ) .await?;
 
-        assert!(credential.contains(r##"type":["VerifiableCredential"],"issuer":"did:evan:EiAOD3RUcQrRXNZIR8BIEXuGvixcUj667_5fdeX-Sp3PpA"##));
+        assert!(credential.contains(r#"type":["VerifiableCredential"],"issuer":"did:evan:EiAOD3RUcQrRXNZIR8BIEXuGvixcUj667_5fdeX-Sp3PpA"#));
         assert!(credential.contains(r##"credentialSubject":{"id":"did:evan:EiAOD3RUcQrRXNZIR8BIEXuGvixcUj667_5fdeX-Sp3PpA","data":{"email":"value@x.com"}},"credentialSchema":{"id":"did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw","type":"EvanVCSchema"},"credentialStatus":{"id":"did:evan:zkp:placeholder_status#0","type":"RevocationList2020Status","revocationListIndex":"0","revocationListCredential":"did:evan:zkp:placeholder_status"},"proof":{"type":"BbsBlsSignature2020"##));
 
         Ok(())

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -291,7 +291,7 @@ impl<'a> Credential<'a> {
     ) -> Result<String, CredentialError> {
         let credential_subject: CredentialSubject = serde_json::from_str(credential_subject_str)?;
         let credential_subject_copy: CredentialSubject = serde_json::from_str(credential_subject_str)?;
-        let subject_did = credential_subject.id.unwrap_or("did:evan:default".to_string());
+        let subject_did = credential_subject.id.ok_or("no subject did found".to_string()).unwrap();
         let subject_did_copy = subject_did.clone();
         let subject_did_str = subject_did_copy.as_str();
         let subject_did_str_copy = subject_did_str.clone();

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -291,7 +291,7 @@ impl<'a> Credential<'a> {
             .create_credential_request(
                 issuer_public_key.as_str(),
                 bbs_secret,
-                &credential_values_str,
+                credential_values_str.as_str(),
                 offer.as_str(),
                 schema_did,
             ).await?;
@@ -792,6 +792,38 @@ mod tests {
             }
             _ => assert!(false, "revocation check failed with unexpected error"),
         };
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[cfg(feature = "plugin-did-sidetree")]
+    async fn helper_can_create_self_issued_credential() -> Result<()> {
+        let mut vade_evan = VadeEvan::new(crate::VadeEvanConfig {
+            target: "test",
+            signer: "remote|http://127.0.0.1:7070/key/sign",
+        })?;
+        let credential_subject_str = r#"{
+            "id": "did:evan:EiAJqjQKlTF4lsgUKL1Tvmvgm3ECXtyVA08Optz8k_W6Lg",
+            "data": {
+                "email": "value@x.com"
+            }
+        }"#;
+        let bbs_secret = r#""OASkVMA8q6b3qJuabvgaN9K1mKoqptCv4SCNvRmnWuI=""#;
+        let bbs_private_key = r#""16bd56948ba09a626551b3f39093da305b347ef4ef2182b2e667dfa5aaa0d4cd""#;
+
+        let credential = vade_evan
+            .helper_create_self_issued_credential(
+                SCHEMA_DID,
+                credential_subject_str,
+                bbs_secret,
+                bbs_private_key,
+                Some(""),
+                Some(""),
+                Some(""),
+            ) .await?;
+
+        assert!(credential.contains("did"));
 
         Ok(())
     }

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -393,12 +393,13 @@ impl<'a> Credential<'a> {
         let _credential_without_proof = serde_json::to_string(&parsed_credential)?;
         let did_doc_nquads = convert_to_nquads(&_credential_without_proof).await?;
         let credential: UnfinishedBbsCredential = serde_json::from_str(credential_str.as_str())?;
+        let credential_copy = credential.clone();
         let payload_finish = FinishCredentialPayload {
             credential,
             master_secret: bbs_secret.to_string(),
             nquads: did_doc_nquads,
             issuer_public_key: issuer_public_key_copy,
-            blinding: request.blind_signature_context,
+            blinding: credential_copy.proof.blind_signature,
         };
         let payload_finish_str = serde_json::to_string(&payload_finish)?;
         let result = self

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -440,8 +440,8 @@ impl<'a> Credential<'a> {
         // Create credential request
         let request_str = self
             .create_credential_request(
-                &issuer_public_key,
-                bbs_secret,
+                &format!("\"{}\"", issuer_public_key),
+                &format!("\"{}\"", bbs_secret),
                 &credential_values_str,
                 &offer_str,
                 schema_did,
@@ -475,7 +475,7 @@ impl<'a> Credential<'a> {
         parsed_credential.remove("proof");
         let _credential_without_proof = serde_json::to_string(&parsed_credential)?;
         let did_doc_nquads = convert_to_nquads(&_credential_without_proof).await?;
-        let credential: UnfinishedBbsCredential = serde_json::from_str(&credential_str)?;
+        let credential: UnfinishedBbsCredential = serde_json::from_str(credential_str.as_str())?;
         let payload_finish = FinishCredentialPayload {
             credential,
             master_secret: bbs_secret.to_string(),

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -299,7 +299,7 @@ impl<'a> Credential<'a> {
         let issuer_public_key = self
             .get_issuer_public_key(&subject_did, "#bbs-key-1")
             .await?;
-        let issuer_public_key_str = serde_json::to_string(issuer_public_key.as_str())?;
+        let issuer_public_key_copy= issuer_public_key.clone();
         let use_valid_until= if exp_date.is_some() { true } else { false };
         let exp_date_str = exp_date.unwrap_or("");
 
@@ -397,7 +397,7 @@ impl<'a> Credential<'a> {
             credential,
             master_secret: bbs_secret.to_string(),
             nquads: did_doc_nquads,
-            issuer_public_key: issuer_public_key_str.as_str().to_string(),
+            issuer_public_key: issuer_public_key_copy,
             blinding: request.blind_signature_context,
         };
         let payload_finish_str = serde_json::to_string(&payload_finish)?;

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -395,7 +395,7 @@ impl<'a> Credential<'a> {
         };
         let revocation_list_index = credential_revocation_id.unwrap_or("0").to_string();
         let revocation_list_credential = credential_revocation_did
-            .unwrap_or("did:evan:zkp:placeholder_status")
+            .unwrap_or("no_status")
             .to_string();
         let status_id = [
             revocation_list_credential.clone(),
@@ -419,6 +419,14 @@ impl<'a> Credential<'a> {
             credential_schema,
             credential_status,
         };
+
+        // leave default "0" index, but remove credential_status if credential_revocation_did was empty
+        if (credential_status.id.contains("no_status")) {
+            // unsigned_credential.credential_status.delete();  is it even possible in Rust?
+            // looked for it, two possible solutions - either custom serialization, or refactoring UnsignedBbsCredential
+            // Please advise! -- DVG --
+        }
+
         let unsigned_credential_str = serde_json::to_string(&unsigned_credential)?;
         let nquads_vc = convert_to_nquads(&unsigned_credential_str).await?;
 

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,11 +1,11 @@
-#[cfg(feature = "plugin-vc-zkp-bbs")]
+#[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
 mod credential;
 mod datatypes;
 #[cfg(feature = "plugin-did-sidetree")]
 mod did;
 mod version_info;
 
-#[cfg(feature = "plugin-vc-zkp-bbs")]
+#[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
 pub(crate) use credential::{Credential, CredentialError};
 #[cfg(feature = "plugin-did-sidetree")]
 pub(crate) use did::Did;

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,24 @@ async fn main() -> Result<()> {
                     .await?;
                 "".to_string()
             }
+            #[cfg(feature = "plugin-vc-zkp-bbs")]
+            ("create_self_issued_credential", Some(sub_m)) => {
+                get_vade_evan(sub_m)?
+                    .helper_create_self_issued_credential(
+                        get_argument_value(sub_m, "schema_did", None),
+                        get_argument_value(sub_m, "issuer_did", None),
+                        get_argument_value(sub_m, "subject_did", None),
+                        get_argument_value(sub_m, "issuer_public_key", None),
+                        get_argument_value(sub_m, "bbs_secret", None),
+                        get_argument_value(sub_m, "bbs_private_key", None),
+                        get_argument_value(sub_m, "credential_values", None),
+                        get_optional_argument_value(sub_m, "credential_revocation_did"),
+                        get_optional_argument_value(sub_m, "credential_revocation_id"),
+                        get_optional_argument_value(sub_m, "exp_date"),
+                    )
+                    .await?;
+                "".to_string()
+            }
             _ => {
                 bail!("invalid subcommand");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,7 +172,7 @@ async fn main() -> Result<()> {
             }
         },
         ("helper", Some(sub_m)) => match sub_m.subcommand() {
-            #[cfg(feature = "plugin-vc-zkp-bbs")]
+            #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
             ("create_credential_offer", Some(sub_m)) => {
                 let use_valid_until = match get_optional_argument_value(sub_m, "use_valid_until") {
                     Some(value) => value.to_lowercase() == "true",
@@ -187,7 +187,7 @@ async fn main() -> Result<()> {
                     )
                     .await?
             }
-            #[cfg(feature = "plugin-vc-zkp-bbs")]
+            #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
             ("create_credential_request", Some(sub_m)) => {
                 get_vade_evan(sub_m)?
                     .helper_create_credential_request(
@@ -220,7 +220,7 @@ async fn main() -> Result<()> {
                     )
                     .await?
             }
-            #[cfg(feature = "plugin-vc-zkp-bbs")]
+            #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
             ("verify_credential", Some(sub_m)) => {
                 get_vade_evan(sub_m)?
                     .helper_verify_credential(
@@ -241,7 +241,7 @@ async fn main() -> Result<()> {
                     .await?;
                 "".to_string()
             }
-            #[cfg(feature = "plugin-vc-zkp-bbs")]
+            #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
             ("create_self_issued_credential", Some(sub_m)) => {
                 get_vade_evan(sub_m)?
                     .helper_create_self_issued_credential(
@@ -282,7 +282,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         .setting(AppSettings::SubcommandRequiredElseHelp);
 
     cfg_if::cfg_if! {
-        if #[cfg(feature = "plugin-vc-zkp-bbs")] {
+        if #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("create_credential_offer")
                     .about("Creates a `CredentialOffer` message. A `CredentialOffer` is sent by an issuer and is the response to a `CredentialProposal`. The `CredentialOffer` specifies which schema the issuer is capable and willing to use for credential issuance.")
@@ -295,7 +295,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     }
 
     cfg_if::cfg_if! {
-        if #[cfg(feature = "plugin-vc-zkp-bbs")] {
+        if #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("create_credential_request")
                     .about("Requests a credential. This message is the response to a credential offering and is sent by the potential credential holder. It incorporates the target schema, credential definition offered by the issuer, and the encoded values the holder wants to get signed. The credential is not stored on-chain and needs to be kept private.")
@@ -340,7 +340,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     }
 
     cfg_if::cfg_if! {
-        if #[cfg(feature = "plugin-vc-zkp-bbs")] {
+        if #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("verify_credential")
                     .about("Verifies a given credential by checking if given master secret was incorporated into proof and if proof was signed with issuers public key.")
@@ -358,6 +358,22 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .arg(get_clap_argument("credential")?)
                     .arg(get_clap_argument("update_key")?)
                     .arg(get_clap_argument("private_key")?)
+            );
+        } else {}
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))] {
+            subcommand = subcommand.subcommand(
+                SubCommand::with_name("create_self_issued_credential")
+                    .about("Creates a self issued credential.")
+                    .arg(get_clap_argument("schema_did")?)
+                    .arg(get_clap_argument("credential_subject")?)
+                    .arg(get_clap_argument("bbs_secret")?)
+                    .arg(get_clap_argument("bbs_private_key")?)
+                    .arg(get_clap_argument("credential_revocation_did")?)
+                    .arg(get_clap_argument("credential_revocation_id")?)
+                    .arg(get_clap_argument("exp_date")?)
             );
         } else {}
     }
@@ -514,7 +530,7 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     }
 
     cfg_if::cfg_if! {
-        if #[cfg(any(feature = "plugin-vc-zkp-bbs", feature = "plugin-jwt-vct"))] {
+        if #[cfg(any(feature = "plugin-vc-zkp-bbs", feature = "plugin-jwt-vc"))] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("issue_credential")
                     .about("Issues a new credential.")
@@ -625,7 +641,7 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     }
 
     cfg_if::cfg_if! {
-        if #[cfg(any(feature = "plugin-vc-zkp-bbs", feature = "plugin-jwt-vct"))] {
+        if #[cfg(any(feature = "plugin-vc-zkp-bbs", feature = "plugin-jwt-vc"))] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("verify_proof")
                     .about("Verifies a one or multiple proofs sent in a proof presentation.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,8 +249,8 @@ async fn main() -> Result<()> {
                         get_argument_value(sub_m, "credential_subject", None),
                         get_argument_value(sub_m, "bbs_secret", None),
                         get_argument_value(sub_m, "bbs_private_key", None),
-                        get_optional_argument_value(sub_m, "credential_revocation_did"),
-                        get_optional_argument_value(sub_m, "credential_revocation_id"),
+                        get_argument_value(sub_m, "credential_revocation_did", None),
+                        get_argument_value(sub_m, "credential_revocation_id", None),
                         get_optional_argument_value(sub_m, "exp_date"),
                     )
                     .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,12 +235,9 @@ async fn main() -> Result<()> {
                 get_vade_evan(sub_m)?
                     .helper_create_self_issued_credential(
                         get_argument_value(sub_m, "schema_did", None),
-                        get_argument_value(sub_m, "issuer_did", None),
-                        get_argument_value(sub_m, "subject_did", None),
-                        get_argument_value(sub_m, "issuer_public_key", None),
+                        get_argument_value(sub_m, "credential_subject", None),
                         get_argument_value(sub_m, "bbs_secret", None),
                         get_argument_value(sub_m, "bbs_private_key", None),
-                        get_argument_value(sub_m, "credential_values", None),
                         get_optional_argument_value(sub_m, "credential_revocation_did"),
                         get_optional_argument_value(sub_m, "credential_revocation_id"),
                         get_optional_argument_value(sub_m, "exp_date"),

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -275,8 +275,8 @@ cfg_if::cfg_if! {
             credential_subject_str: String,
             bbs_secret: String,
             bbs_private_key: String,
-            credential_revocation_did: Option<String>,
-            credential_revocation_id: Option<String>,
+            credential_revocation_did: String,
+            credential_revocation_id: String,
             exp_date: Option<String>,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
@@ -286,8 +286,8 @@ cfg_if::cfg_if! {
                     &credential_subject_str,
                     &bbs_secret,
                     &bbs_private_key,
-                    credential_revocation_did.as_deref(),
-                    credential_revocation_id.as_deref(),
+                    &credential_revocation_did,
+                    &credential_revocation_id,
                     exp_date.as_deref(),
                 ).await
                 .map_err(jsify_vade_evan_error)?;

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -193,7 +193,7 @@ cfg_if::cfg_if! {
             Ok(Some(did_update_key))
         }
 
-        #[cfg(feature = "plugin-vc-zkp-bbs")]
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
         #[wasm_bindgen]
         pub async fn helper_create_credential_offer(
             schema_did: String,
@@ -213,7 +213,7 @@ cfg_if::cfg_if! {
             Ok(offer)
         }
 
-        #[cfg(feature = "plugin-vc-zkp-bbs")]
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
         #[wasm_bindgen]
         pub async fn helper_create_credential_request(
             issuer_public_key: String,
@@ -252,7 +252,7 @@ cfg_if::cfg_if! {
             Ok("".to_string())
         }
 
-        #[cfg(feature = "plugin-vc-zkp-bbs")]
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
         #[wasm_bindgen]
         pub async fn helper_verify_credential(
             credential: String,
@@ -263,6 +263,32 @@ cfg_if::cfg_if! {
                 .helper_verify_credential(
                     &credential,
                     &master_secret,
+                ).await
+                .map_err(jsify_vade_evan_error)?;
+            Ok("".to_string())
+        }
+
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+        #[wasm_bindgen]
+        pub async fn helper_create_self_issued_credential(
+            schema_did: String,
+            credential_subject_str: String,
+            bbs_secret: String,
+            bbs_private_key: String,
+            credential_revocation_did: Option<String>,
+            credential_revocation_id: Option<String>,
+            exp_date: Option<String>,
+        ) -> Result<String, JsValue> {
+            let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
+            vade_evan
+                .helper_create_self_issued_credential(
+                    &schema_did,
+                    &credential_subject_str,
+                    &bbs_secret,
+                    &bbs_private_key,
+                    credential_revocation_did.as_deref(),
+                    credential_revocation_id.as_deref(),
+                    exp_date.as_deref(),
                 ).await
                 .map_err(jsify_vade_evan_error)?;
             Ok("".to_string())


### PR DESCRIPTION
For an easy to use function in the new vade helpers section, we want to create a first function for self issuing credentials in the helper.



**Details**

This function will receive the following parameters:

- CredentialSchema DID 

- Credential Subject map (example)

> {
>   "id": "did:evan:1234",
>   "data": {
>     "test": "value"
>   }
> }

- BBS secret

- BBS private key

- (optional) credential revocation did and id

- (optional) expiration date



The function will then create a valid self issued credential and executes the required steps to create a credential:

- Create Credential Request

- Issue Credential with the Request

- Finalize the credential (with the blind signature)

- Return the created credential



The credential will have an auto generated uuid as id and the “issuance” date will be set to the current time.



**Acceptance Critieria**

Self issued credentials can be created with the easy to use api