### PR TITLE
implement revoke credential helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 .DS_Store
+.vscode/

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,6 +11,7 @@
 - add `create_credential_offer` helper function
 - add `helper_verify_credential` helper function
 - add `helper_did_create` and `helper_did_update` functions
+- add `helper_revoke_credential` function
 
 ### Fixes
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -492,7 +492,7 @@ impl VadeEvan {
     ///
     /// * `credential` - credential to be revovked as serialized JSON
     /// * `update_key_jwk` - update key in jwk format as serialized JSON
-    /// * `private_key` - optional private key for local signer to be used for signing
+    /// * `private_key` - private key for local signer to be used for signing
     ///
     /// # Example
     ///
@@ -552,7 +552,7 @@ impl VadeEvan {
     ///
     ///             // revoke the credential issuer
     ///             vade_evan
-    ///                 .helper_revoke_credential(credential, update_key_jwk, Some("dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106"))
+    ///                 .helper_revoke_credential(credential, update_key_jwk, "dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106")
     ///                 .await?;
     ///
     ///             Ok(())
@@ -566,7 +566,7 @@ impl VadeEvan {
         &mut self,
         credential: &str,
         update_key_jwk: &str,
-        private_key: Option<&str>,
+        private_key: &str,
     ) -> Result<String, VadeEvanError> {
         let mut credential_helper = Credential::new(self)?;
         credential_helper

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -491,7 +491,7 @@ impl VadeEvan {
     /// # Arguments
     ///
     /// * `credential` - credential to be revovked as serialized JSON
-    /// * `update_key_jwk` - update key  in jwk format as serialized JSON
+    /// * `update_key_jwk` - update key in jwk format as serialized JSON
     /// * `private_key` - optional private key for local signer to be used for signing
     ///
     /// # Example

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -486,6 +486,93 @@ impl VadeEvan {
             .map_err(|err| err.into())
     }
 
+    /// Revokes a given credential with the help of vade and updates revocation list credential
+    ///
+    /// # Arguments
+    ///
+    /// * `credential` - credential to be revovked as serialized JSON
+    /// * `update_key_jwk` - update key  in jwk format as serialized JSON
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// cfg_if::cfg_if! {
+    ///     if #[cfg(not(all(feature = "target-c-lib", feature = "capability-sdk")))] {
+    ///         use anyhow::Result;
+    ///         use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
+    ///
+    ///         async fn example() -> Result<()> {
+    ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
+    ///             let credential = r###"{
+    ///                 "id": "uuid:70b7ec4e-f035-493e-93d3-2cf5be4c7f88",
+    ///                 "type": [
+    ///                     "VerifiableCredential"
+    ///                 ],
+    ///                 "proof": {
+    ///                     "type": "BbsBlsSignature2020",
+    ///                     "created": "2023-02-01T14:08:17.000Z",
+    ///                     "signature": "kvSyi40dnZ5S3/mSxbSUQGKLpyMXDQNLCPtwDGM9GsnNNKF7MtaFHXIbvXaVXku0EY/n2uNMQ2bmK2P0KEmzgbjRHtzUOWVdfAnXnVRy8/UHHIyJR471X6benfZk8KG0qVqy+w67z9g628xRkFGA5Q==",
+    ///                     "proofPurpose": "assertionMethod",
+    ///                     "verificationMethod": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA#bbs-key-1",
+    ///                     "credentialMessageCount": 13,
+    ///                     "requiredRevealStatements": []
+    ///                 },
+    ///                 "issuer": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
+    ///                 "@context": [
+    ///                     "https://www.w3.org/2018/credentials/v1",
+    ///                     "https://schema.org/",
+    ///                     "https://w3id.org/vc-revocation-list-2020/v1"
+    ///                 ],
+    ///                 "issuanceDate": "2023-02-01T14:08:09.849Z",
+    ///                 "credentialSchema": {
+    ///                     "id": "did:evan:EiCimsy3uWJ7PivWK0QUYSCkImQnjrx6fGr6nK8XIg26Kg",
+    ///                     "type": "EvanVCSchema"
+    ///                 },
+    ///                 "credentialStatus": {
+    ///                     "id": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA#4",
+    ///                     "type": "RevocationList2020Status",
+    ///                     "revocationListIndex": "4",
+    ///                     "revocationListCredential": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA"
+    ///                 },
+    ///                 "credentialSubject": {
+    ///                     "id": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
+    ///                     "data": {
+    ///                         "bio": "biography"
+    ///                     }
+    ///                 }
+    ///             }"###;
+    ///             let update_key_jwk = r###"{
+    ///                 "kty": "EC",
+    ///                 "crv": "secp256k1",
+    ///                 "x": "n194_Pew6DvVr1vFsInIP5XlJESYIj_h3-_5XJ5Fudw",
+    ///                 "y": "Z-o5enGPMVFi4U4oA2prWLYDcyATXtHvkEO2yvsOBbI",
+    ///                 "d": "AtmtD2JOaydG5WAHrjkYS_VzFkWo2B0Ok-8T3uClFt4"
+    ///             }"###;
+    ///
+    ///             // revoke the credential issuer
+    ///             vade_evan
+    ///                 .helper_revoke_credential(credential, update_key_jwk)
+    ///                 .await?;
+    ///
+    ///             Ok(())
+    ///         }
+    ///     } else {
+    ///         // currently no example for capability-sdk and target-c-lib/target-java-lib
+    ///     }
+    /// }
+    #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+    pub async fn helper_revoke_credential(
+        &mut self,
+        credential: &str,
+        update_key_jwk: &str,
+    ) -> Result<String, VadeEvanError> {
+        let mut credential_helper = Credential::new(self)?;
+        credential_helper
+            .revoke_credential(credential, update_key_jwk)
+            .await
+            .map_err(|err| err.into())
+    }
+
     /// Runs a custom function, this allows to use `Vade`s API for custom calls, that do not belong
     /// to `Vade`s core functionality but may be required for a projects use cases.
     ///
@@ -1122,7 +1209,7 @@ impl VadeEvan {
     /// ```
     /// cfg_if::cfg_if! {
     /// if #[cfg(not(all(feature = "target-c-lib", feature = "capability-sdk")))] {
-    /// 
+    ///
     ///     use anyhow::Result;
     ///     use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
     ///

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -552,7 +552,7 @@ impl VadeEvan {
     ///
     ///             // revoke the credential issuer
     ///             vade_evan
-    ///                 .helper_revoke_credential(credential, update_key_jwk)
+    ///                 .helper_revoke_credential(credential, update_key_jwk, Some("dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106"))
     ///                 .await?;
     ///
     ///             Ok(())

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -492,6 +492,7 @@ impl VadeEvan {
     ///
     /// * `credential` - credential to be revovked as serialized JSON
     /// * `update_key_jwk` - update key  in jwk format as serialized JSON
+    /// * `private_key` - optional private key for local signer to be used for signing
     ///
     /// # Example
     ///
@@ -565,10 +566,11 @@ impl VadeEvan {
         &mut self,
         credential: &str,
         update_key_jwk: &str,
+        private_key: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         let mut credential_helper = Credential::new(self)?;
         credential_helper
-            .revoke_credential(credential, update_key_jwk)
+            .revoke_credential(credential, update_key_jwk, private_key)
             .await
             .map_err(|err| err.into())
     }

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -589,6 +589,28 @@ pub extern "C" fn execute_vade(
                 Ok("".to_string())
             }
         }),
+
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+        "helper_revoke_credential" => runtime.block_on({
+            async {
+                let mut vade_evan = get_vade_evan(
+                    Some(&str_config),
+                    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+                    ptr_request_list,
+                    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+                    request_function_callback,
+                )
+                .map_err(stringify_generic_error)?;
+                vade_evan
+                    .helper_revoke_credential(
+                        arguments_vec.get(0).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(1).unwrap_or_else(|| &no_args),
+                    )
+                    .await
+                    .map_err(stringify_vade_evan_error)?;
+                Ok("".to_string())
+            }
+        }),
         #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "run_custom_function" => runtime.block_on({
             execute_vade_function!(

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -605,7 +605,7 @@ pub extern "C" fn execute_vade(
                     .helper_revoke_credential(
                         arguments_vec.get(0).unwrap_or_else(|| &no_args),
                         arguments_vec.get(1).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(2).map(|x| &**x),
+                        arguments_vec.get(2).unwrap_or_else(|| &no_args),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)?;

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -605,6 +605,7 @@ pub extern "C" fn execute_vade(
                     .helper_revoke_credential(
                         arguments_vec.get(0).unwrap_or_else(|| &no_args),
                         arguments_vec.get(1).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(2).map(|x| &**x),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)?;

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -283,17 +283,14 @@ impl<'a> Credential<'a> {
         &mut self,
         credential_str: &str,
         update_key_jwk: &str,
-        private_key: Option<&str>,
+        private_key: &str,
     ) -> Result<String, CredentialError> {
         let credential: BbsCredential = serde_json::from_str(credential_str)?;
         let revocation_list: RevocationListCredential = self
             .get_did_document(&credential.credential_status.revocation_list_credential)
             .await?;
 
-        let proving_key = match private_key {
-            Some(key) => key,
-            None => &credential.issuer,
-        };
+        let proving_key = private_key;
         let payload = RevokeCredentialPayload {
             issuer: credential.issuer.clone(),
             revocation_list: revocation_list.clone(),
@@ -768,7 +765,7 @@ mod tests {
             .helper_revoke_credential(
                 &serde_json::to_string(&credential)?,
                 &serde_json::to_string(&update_key)?,
-                Some("dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106"),
+                "dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106",
             )
             .await;
         assert!(revoke_result.is_ok());

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -274,7 +274,7 @@ impl<'a> Credential<'a> {
     /// # Arguments
     /// * `credential_str` - credential to be revoked in seralized string format
     /// * `updated_key_jwk` - public key in jwk format to sign did update
-    /// * `private_key` - bbs private key to sign revocaton request 
+    /// * `private_key` - bbs private key to sign revocaton request
     ///
     /// # Returns
     /// * `String` - the result of updated revocation list doc after credential revocation

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -269,6 +269,15 @@ impl<'a> Credential<'a> {
         Ok(())
     }
 
+    /// Revokes a given credential with the help of vade and updates revocation list credential
+    ///
+    /// # Arguments
+    /// * `credential_str` - credential to be revoked in seralized string format
+    /// * `updated_key_jwk` - public key in jwk format to sign did update
+    /// * `private_key` - bbs private key to sign revocaton request 
+    ///
+    /// # Returns
+    /// * `String` - the result of updated revocation list doc after credential revocation
     #[cfg(feature = "plugin-did-sidetree")]
     pub async fn revoke_credential(
         &mut self,

--- a/src/helpers/datatypes/did_types.rs
+++ b/src/helpers/datatypes/did_types.rs
@@ -26,6 +26,7 @@ pub enum DIDOperationType {
     RemoveKey,
     AddServiceEnpoint,
     RemoveServiceEnpoint,
+    ReplaceDidDoc
 }
 
 impl FromStr for DIDOperationType {
@@ -36,6 +37,7 @@ impl FromStr for DIDOperationType {
             "RemoveKey" => Ok(DIDOperationType::RemoveKey),
             "AddServiceEnpoint" => Ok(DIDOperationType::AddServiceEnpoint),
             "RemoveServiceEnpoint" => Ok(DIDOperationType::RemoveServiceEnpoint),
+            "ReplaceDidDoc" => Ok(DIDOperationType::ReplaceDidDoc),
             _ => Err(()),
         }
     }
@@ -64,6 +66,8 @@ pub struct VerificationMethod {
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicKeyJwk {
+    pub crv: String,
+    pub kty: String,
     pub x: String,
     pub y: Option<String>,
 }

--- a/src/helpers/did.rs
+++ b/src/helpers/did.rs
@@ -23,6 +23,7 @@ use vade_sidetree::{
         RemoveServices,
         Service,
         UpdateType,
+        JsonPatch
     },
     CreateDidPayload,
 };
@@ -212,6 +213,9 @@ impl<'a> Did<'a> {
                 patch = Patch::RemoveServices(RemoveServices {
                     ids: vec![service_id_to_remove],
                 });
+            }
+            DIDOperationType::ReplaceDidDoc =>{
+                patch = Patch::IetfJsonPatch(JsonPatch)
             }
         };
 

--- a/src/helpers/did.rs
+++ b/src/helpers/did.rs
@@ -1,11 +1,7 @@
 use std::str::FromStr;
 
 use crate::api::{VadeEvan, VadeEvanError};
-use crate::helpers::datatypes::{
-    DIDOperationType,
-    EVAN_METHOD,
-    TYPE_SIDETREE_OPTIONS,
-};
+use crate::helpers::datatypes::{DIDOperationType, EVAN_METHOD, TYPE_SIDETREE_OPTIONS};
 use base64::{decode_config, encode_config, URL_SAFE_NO_PAD};
 use uuid::Uuid;
 
@@ -14,6 +10,8 @@ use vade_sidetree::{
         AddPublicKeys,
         AddServices,
         DidUpdatePayload,
+        IetfJsonPatch,
+        JsonPatch,
         JsonWebKey,
         JsonWebKeyPublic,
         Patch,
@@ -23,7 +21,6 @@ use vade_sidetree::{
         RemoveServices,
         Service,
         UpdateType,
-        JsonPatch
     },
     CreateDidPayload,
 };
@@ -214,8 +211,18 @@ impl<'a> Did<'a> {
                     ids: vec![service_id_to_remove],
                 });
             }
-            DIDOperationType::ReplaceDidDoc =>{
-                patch = Patch::IetfJsonPatch(JsonPatch)
+            DIDOperationType::ReplaceDidDoc => {
+                let updated_did_doc = serde_json::from_str(payload).map_err(|err| VadeEvanError::InternalError {
+                        source_message: err.to_string(),
+                    })?;
+                let ietf_json_patch = IetfJsonPatch {
+                    op: "replace".to_owned(),
+                    path: "".to_owned(),
+                    value: updated_did_doc,
+                };
+                patch = Patch::IetfJsonPatch(JsonPatch {
+                    patches: vec![ietf_json_patch],
+                })
             }
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,6 +236,7 @@ async fn main() -> Result<()> {
                     .helper_revoke_credential(
                         get_argument_value(sub_m, "credential", None),
                         get_argument_value(sub_m, "bbs_public_key", None),
+                        get_optional_argument_value(sub_m, "private_key")
                     )
                     .await?;
                 "".to_string()
@@ -340,6 +341,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .about("Revokes a given credential with vade and updates the revocation list credential.")
                     .arg(get_clap_argument("credential")?)
                     .arg(get_clap_argument("bbs_public_key")?)
+                    .arg(get_clap_argument("private_key")?)
             );
         } else {}
     }
@@ -816,6 +818,11 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
             .value_name("master_secret")
             .required(true)
             .help("master secret incorporated as a blinded value into the proof of the credential")
+            .takes_value(true),
+        "private_key" => Arg::with_name("private_key")
+            .long("private_key")
+            .value_name("private_key")
+            .help("optional private key to be supplied for local signer")
             .takes_value(true),
         _ => {
             bail!("invalid arg_name: '{}'", &arg_name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,7 +235,7 @@ async fn main() -> Result<()> {
                 get_vade_evan(sub_m)?
                     .helper_revoke_credential(
                         get_argument_value(sub_m, "credential", None),
-                        get_argument_value(sub_m, "bbs_public_key", None),
+                        get_argument_value(sub_m, "update_key", None),
                         get_optional_argument_value(sub_m, "private_key")
                     )
                     .await?;
@@ -340,7 +340,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                 SubCommand::with_name("revoke_credential")
                     .about("Revokes a given credential with vade and updates the revocation list credential.")
                     .arg(get_clap_argument("credential")?)
-                    .arg(get_clap_argument("bbs_public_key")?)
+                    .arg(get_clap_argument("update_key")?)
                     .arg(get_clap_argument("private_key")?)
             );
         } else {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -230,6 +230,16 @@ async fn main() -> Result<()> {
                     .await?;
                 "".to_string()
             }
+            #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+            ("revoke_credential", Some(sub_m)) => {
+                get_vade_evan(sub_m)?
+                    .helper_revoke_credential(
+                        get_argument_value(sub_m, "credential", None),
+                        get_argument_value(sub_m, "bbs_public_key", None),
+                    )
+                    .await?;
+                "".to_string()
+            }
             _ => {
                 bail!("invalid subcommand");
             }
@@ -323,6 +333,16 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
         } else {}
     }
 
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))] {
+            subcommand = subcommand.subcommand(
+                SubCommand::with_name("revoke_credential")
+                    .about("Revokes a given credential with vade and updates the revocation list credential.")
+                    .arg(get_clap_argument("credential")?)
+                    .arg(get_clap_argument("bbs_public_key")?)
+            );
+        } else {}
+    }
     Ok(app.subcommand(subcommand))
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,7 +236,7 @@ async fn main() -> Result<()> {
                     .helper_revoke_credential(
                         get_argument_value(sub_m, "credential", None),
                         get_argument_value(sub_m, "update_key", None),
-                        get_optional_argument_value(sub_m, "private_key")
+                        get_argument_value(sub_m, "private_key", None),
                     )
                     .await?;
                 "".to_string()
@@ -822,7 +822,8 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
         "private_key" => Arg::with_name("private_key")
             .long("private_key")
             .value_name("private_key")
-            .help("optional private key to be supplied for local signer")
+            .required(true)
+            .help("private key to be supplied for local signer")
             .takes_value(true),
         _ => {
             bail!("invalid arg_name: '{}'", &arg_name);

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -239,14 +239,14 @@ cfg_if::cfg_if! {
         pub async fn helper_revoke_credential(
             credential: String,
             update_key_jwk: String,
-            private_key: Option<String>,
+            private_key: String,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
             vade_evan
                 .helper_revoke_credential(
                     &credential,
                     &update_key_jwk,
-                    private_key.as_ref().map(|x| x.as_ref())
+                    &private_key,
                 ).await
                 .map_err(jsify_vade_evan_error)?;
             Ok("".to_string())

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -239,12 +239,14 @@ cfg_if::cfg_if! {
         pub async fn helper_revoke_credential(
             credential: String,
             update_key_jwk: String,
+            private_key: Option<String>,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
             vade_evan
                 .helper_revoke_credential(
                     &credential,
                     &update_key_jwk,
+                    private_key.as_ref().map(|x| x.as_ref())
                 ).await
                 .map_err(jsify_vade_evan_error)?;
             Ok("".to_string())

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -234,6 +234,22 @@ cfg_if::cfg_if! {
             Ok(credential_result)
         }
 
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+        #[wasm_bindgen]
+        pub async fn helper_revoke_credential(
+            credential: String,
+            update_key_jwk: String,
+        ) -> Result<String, JsValue> {
+            let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
+            vade_evan
+                .helper_revoke_credential(
+                    &credential,
+                    &update_key_jwk,
+                ).await
+                .map_err(jsify_vade_evan_error)?;
+            Ok("".to_string())
+        }
+
         #[cfg(feature = "plugin-vc-zkp-bbs")]
         #[wasm_bindgen]
         pub async fn helper_verify_credential(


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Implements revoke credential helper 

## Details 

- add revoke credential helper to src/helpers ,
- add helper_revoke_credential to vade api
- add test case
- add helper to bindings(c and wasm) 
- add helper to cli
<!--- HOW does it change stuff? -->

## Impact on other parties

<!-- Delete points, that do not apply. Add comments to those that apply. -->
- new option is added to cli in helper subcommand to revoke credential
- c-lib has  helper function to revoke credentials as well by passing direct values instead of options, method and payload params
