### PR TITLE
Remove getrandom from dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,10 +1705,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
  "cfg-if 1.0.0",
- "js-sys",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -5217,7 +5215,6 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "flate2",
- "getrandom 0.1.16",
  "jni",
  "log",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,6 @@ openssl = { version = "*", features = ["vendored"] }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 console_error_panic_hook = "0.1.6"
 console_log = { version = "0.2", features = ["color"] }
-getrandom = { version = "0.1", features = ["wasm-bindgen"] }
 log = "0.4.17"
 serde_derive = "1.0.114"
 serde-wasm-bindgen = "0.4.5"

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -12,6 +12,7 @@
 - add `helper_verify_credential` helper function
 - add `helper_did_create` and `helper_did_update` functions
 - add `helper_revoke_credential` function
+- remove getrandom from dependencies
 
 ### Fixes
 


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Removes getrandom from cargo dependencies, getrandom is currently not used anywhere in vade-evan 

## Details 

- remove getrandon dependency
<!--- HOW does it change stuff? -->

## Impact on other parties

<!-- Delete points, that do not apply. Add comments to those that apply. -->
