### PR TITLE
Add helper for creating proof requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5135,6 +5135,7 @@ dependencies = [
  "jni",
  "log",
  "openssl",
+ "regex",
  "serde",
  "serde-wasm-bindgen 0.4.5",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ plugin-jwt-vc = ["capability-vc-zkp", "plugin-signer", "vade-jwt-vc"]
 
 plugin-signer = ["vade-signer"]
 
-plugin-vc-zkp-bbs = ["base64", "bbs", "capability-vc-zkp", "flate2", "plugin-signer", "ssi", "vade-evan-bbs"]
+plugin-vc-zkp-bbs = ["base64", "bbs", "capability-vc-zkp", "flate2", "plugin-signer", "regex", "ssi", "vade-evan-bbs"]
 
 # enable support for using the `c_lib` module to process requests
 capability-c-lib = ["tokio", "vade-didcomm/portable"]
@@ -138,6 +138,10 @@ default-features= false
 
 [dependencies.flate2]
 version = "1.0.20"
+optional = true
+
+[dependencies.regex]
+version = "1"
 optional = true
 
 [dependencies.ssi]

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -15,6 +15,7 @@
 - pass sdk feature to vade-sidtree plugin
 - remove getrandom from dependencies
 - add `helper_create_self_issued_credential` helper function
+- add `helper_create_proof_request`
 
 ### Fixes
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -635,12 +635,13 @@ impl VadeEvan {
     /// * `credential_subject_str` - JSON string of CredentialSubject structure
     /// * `bbs_secret` - BBS secret
     /// * `bbs_private_key` - BBS private key
-    /// * `credential_revocation_did` - revocation list DID (or `None` if no revocation is used)
-    /// * `credential_revocation_id` - index in revocation list (or `None` if no revocation is used)
+    /// * `credential_revocation_did` - revocation list DID
+    /// * `credential_revocation_id` - index in revocation list
     /// * `exp_date` - expiration date, string, e.g. "1722-12-03T14:23:42.120Z" (or `None` if no expiration date is used)
     ///
     /// # Returns
     /// * credential as JSON serialized [`BbsCredential`](https://docs.rs/vade_evan_bbs/*/vade_evan_bbs/struct.BbsCredential.html)
+    ///
     /// # Example
     ///
     /// ```

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -1351,7 +1351,7 @@ impl VadeEvan {
     ///         let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
     ///         let did = "did:evan:0x123334233232";
     ///         let update_key = r#"{"kty":"EC","crv":"secp256k1","x":"W8rj8Dko_f0KgqY-nzCvzy_pNbVmYyiaY1GpiuvZKsw","y":"E2cKPqGtq55iiyZIdTCe59HgeQ1bdnMcNdbf9tI5ogo","d":"yZv5g_rjyC0nnUii7pxEh7V2M6XZHeJCu5OjfLMNlSI"}"#;
-    ///         let operation = r#"AddServiceEnpoint"#;
+    ///         let operation = r#"AddServiceEndpoint"#;
     ///         let service = r#"{"id":"sds","r#type":"SecureDataStrore","service_endpoint":"www.google.com"}"#;
     ///         let payload = &serde_json::to_string(&service)?;
     ///         let update_response = vade_evan

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -486,11 +486,60 @@ impl VadeEvan {
             .map_err(|err| err.into())
     }
 
+    /// Requests a proof for a credential.
+    /// The proof request consists of the fields the verifier wants to be revealed per schema.
+    ///
+    /// # Arguments
+    ///
+    /// * `schema_did` - DID of schema to request proof for
+    /// * `revealed_attributes` - list of names of revealed attributes in specified schema
+    ///
+    /// # Returns
+    /// * `Option<String>` - A `ProofRequest` as JSON
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// cfg_if::cfg_if! {
+    ///     if #[cfg(not(all(feature = "target-c-lib", feature = "capability-sdk")))] {
+    ///         use anyhow::Result;
+    ///         use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
+    ///
+    ///         async fn example() -> Result<()> {
+    ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
+    ///             let schema_did = "did:evan:EiBrPL8Yif5NWHOzbKvyh1PX1wKVlWvIa6nTG1v8PXytvg";
+    ///             let revealed_attributes = ["zip", "country"];
+    ///
+    ///             vade_evan
+    ///                 .helper_create_proof_request(schema_did, &revealed_attributes)
+    ///                 .await?;
+    ///
+    ///             Ok(())
+    ///         }
+    ///     } else {
+    ///         // currently no example for capability-sdk and target-c-lib/target-java-lib
+    ///     }
+    /// }
+    #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+    pub async fn helper_create_proof_request(
+        &mut self,
+        schema_did: &str,
+        revealed_attributes: &[&str],
+    ) -> Result<String, VadeEvanError> {
+        use crate::helpers::Presentation;
+
+        let mut presentation_helper = Presentation::new(self)?;
+        presentation_helper
+            .create_proof_request(schema_did, revealed_attributes)
+            .await
+            .map_err(|err| err.into())
+    }
+
     /// Revokes a given credential with the help of vade and updates revocation list credential
     ///
     /// # Arguments
     ///
-    /// * `credential` - credential to be revovked as serialized JSON
+    /// * `credential` - credential to be revoked as serialized JSON
     /// * `update_key_jwk` - update key in jwk format as serialized JSON
     /// * `private_key` - private key for local signer to be used for signing
     ///

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -508,7 +508,7 @@ impl VadeEvan {
     ///         async fn example() -> Result<()> {
     ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
     ///             let schema_did = "did:evan:EiBrPL8Yif5NWHOzbKvyh1PX1wKVlWvIa6nTG1v8PXytvg";
-    ///             let revealed_attributes = ["zip", "country"];
+    ///             let revealed_attributes = r#"["zip", "country"]"#;
     ///
     ///             vade_evan
     ///                 .helper_create_proof_request(schema_did, &revealed_attributes)
@@ -524,7 +524,7 @@ impl VadeEvan {
     pub async fn helper_create_proof_request(
         &mut self,
         schema_did: &str,
-        revealed_attributes: &[&str],
+        revealed_attributes: &str,
     ) -> Result<String, VadeEvanError> {
         use crate::helpers::Presentation;
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -492,7 +492,7 @@ impl VadeEvan {
     /// # Arguments
     ///
     /// * `schema_did` - DID of schema to request proof for
-    /// * `revealed_attributes` - list of names of revealed attributes in specified schema
+    /// * `revealed_attributes` - list of names of revealed attributes in specified schema, reveals all if omitted
     ///
     /// # Returns
     /// * `Option<String>` - A `ProofRequest` as JSON
@@ -508,10 +508,10 @@ impl VadeEvan {
     ///         async fn example() -> Result<()> {
     ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
     ///             let schema_did = "did:evan:EiBrPL8Yif5NWHOzbKvyh1PX1wKVlWvIa6nTG1v8PXytvg";
-    ///             let revealed_attributes = r#"["zip", "country"]"#;
+    ///             let revealed_attributes = Some(r#"["zip", "country"]"#);
     ///
     ///             vade_evan
-    ///                 .helper_create_proof_request(schema_did, &revealed_attributes)
+    ///                 .helper_create_proof_request(schema_did, revealed_attributes)
     ///                 .await?;
     ///
     ///             Ok(())
@@ -524,7 +524,7 @@ impl VadeEvan {
     pub async fn helper_create_proof_request(
         &mut self,
         schema_did: &str,
-        revealed_attributes: &str,
+        revealed_attributes: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         use crate::helpers::Presentation;
 

--- a/src/api/vade_evan_error.rs
+++ b/src/api/vade_evan_error.rs
@@ -1,5 +1,6 @@
 #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
 use crate::helpers::CredentialError;
+#[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
 use crate::helpers::PresentationError;
 use thiserror::Error;
 

--- a/src/api/vade_evan_error.rs
+++ b/src/api/vade_evan_error.rs
@@ -1,5 +1,6 @@
 #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
 use crate::helpers::CredentialError;
+use crate::helpers::PresentationError;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -13,6 +14,9 @@ pub enum VadeEvanError {
     #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
     #[error(transparent)]
     CredentialError(#[from] CredentialError),
+    #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+    #[error(transparent)]
+    PresentationError(#[from] PresentationError),
 }
 
 impl From<Box<dyn std::error::Error>> for VadeEvanError {

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -651,7 +651,7 @@ pub extern "C" fn execute_vade(
                 vade_evan
                     .helper_create_proof_request(
                         arguments_vec.get(0).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(1).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(1).map(|v| v.as_str()),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -637,6 +637,26 @@ pub extern "C" fn execute_vade(
                     .map_err(stringify_vade_evan_error)
             }
         }),
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+        "helper_create_proof_request" => runtime.block_on({
+            async {
+                let mut vade_evan = get_vade_evan(
+                    Some(&str_config),
+                    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+                    ptr_request_list,
+                    #[cfg(all(feature = "target-c-lib", feature = "capability-sdk"))]
+                    request_function_callback,
+                )
+                .map_err(stringify_generic_error)?;
+                vade_evan
+                    .helper_create_proof_request(
+                        arguments_vec.get(0).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(1).unwrap_or_else(|| &no_args),
+                    )
+                    .await
+                    .map_err(stringify_vade_evan_error)
+            }
+        }),
         #[cfg(any(feature = "plugin-vc-zkp-bbs"))]
         "run_custom_function" => runtime.block_on({
             execute_vade_function!(

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -479,7 +479,7 @@ impl<'a> Credential<'a> {
         Ok(create_draft_credential_from_schema(
             use_valid_until,
             subject_did,
-            schema,
+            &schema,
         ))
     }
 

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -44,8 +44,6 @@ pub enum CredentialError {
     InvalidVerificationMethod(String),
     #[error("JSON (de)serialization failed")]
     JsonDeSerialization(#[from] serde_json::Error),
-    // #[error("JSON-ld handling failed, {0}")]
-    // JsonLdHandling(String),
     #[error("{0}")]
     JsonLdHandling(#[from] SharedError), // for now only one type of error from shared helper, so just re-package it
     #[error("base64 decoding failed")]

--- a/src/helpers/datatypes/did_types.rs
+++ b/src/helpers/datatypes/did_types.rs
@@ -13,8 +13,8 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-use std::str::FromStr;
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[cfg(feature = "plugin-did-sidetree")]
 pub const TYPE_SIDETREE_OPTIONS: &str = r#"{ "type": "sidetree", "waitForCompletion":true }"#;
@@ -24,9 +24,9 @@ pub const EVAN_METHOD: &str = "did:evan";
 pub enum DIDOperationType {
     AddKey,
     RemoveKey,
-    AddServiceEnpoint,
-    RemoveServiceEnpoint,
-    ReplaceDidDoc
+    AddServiceEndpoint,
+    RemoveServiceEndpoint,
+    ReplaceDidDoc,
 }
 
 impl FromStr for DIDOperationType {
@@ -35,8 +35,8 @@ impl FromStr for DIDOperationType {
         match input {
             "AddKey" => Ok(DIDOperationType::AddKey),
             "RemoveKey" => Ok(DIDOperationType::RemoveKey),
-            "AddServiceEnpoint" => Ok(DIDOperationType::AddServiceEnpoint),
-            "RemoveServiceEnpoint" => Ok(DIDOperationType::RemoveServiceEnpoint),
+            "AddServiceEndpoint" => Ok(DIDOperationType::AddServiceEndpoint),
+            "RemoveServiceEndpoint" => Ok(DIDOperationType::RemoveServiceEndpoint),
             "ReplaceDidDoc" => Ok(DIDOperationType::ReplaceDidDoc),
             _ => Err(()),
         }

--- a/src/helpers/did.rs
+++ b/src/helpers/did.rs
@@ -193,7 +193,7 @@ impl<'a> Did<'a> {
                     ids: vec![key_id_to_remove],
                 });
             }
-            DIDOperationType::AddServiceEnpoint => {
+            DIDOperationType::AddServiceEndpoint => {
                 let service: Service =
                     serde_json::from_str(payload).map_err(|err| VadeEvanError::InternalError {
                         source_message: err.to_string(),
@@ -204,7 +204,7 @@ impl<'a> Did<'a> {
                 });
             }
 
-            DIDOperationType::RemoveServiceEnpoint => {
+            DIDOperationType::RemoveServiceEndpoint => {
                 let service_id_to_remove = payload.to_owned();
 
                 patch = Patch::RemoveServices(RemoveServices {
@@ -212,7 +212,8 @@ impl<'a> Did<'a> {
                 });
             }
             DIDOperationType::ReplaceDidDoc => {
-                let updated_did_doc = serde_json::from_str(payload).map_err(|err| VadeEvanError::InternalError {
+                let updated_did_doc =
+                    serde_json::from_str(payload).map_err(|err| VadeEvanError::InternalError {
                         source_message: err.to_string(),
                     })?;
                 let ietf_json_patch = IetfJsonPatch {
@@ -357,7 +358,7 @@ mod tests {
         let did_update_result = vade_evan
             .helper_did_update(
                 &did_create_result.did.did_document.id,
-                "AddServiceEnpoint",
+                "AddServiceEndpoint",
                 &serde_json::to_string(&did_create_result.update_key)?,
                 &serde_json::to_string(&service)?,
             )
@@ -394,7 +395,7 @@ mod tests {
         let did_update_result = vade_evan
             .helper_did_update(
                 &did_create_result.did.did_document.id,
-                "AddServiceEnpoint",
+                "AddServiceEndpoint",
                 &serde_json::to_string(&did_create_result.update_key)?,
                 &serde_json::to_string(&service)?,
             )
@@ -422,7 +423,7 @@ mod tests {
         let did_update_result = vade_evan
             .helper_did_update(
                 &did_create_result.did.did_document.id,
-                "RemoveServiceEnpoint",
+                "RemoveServiceEndpoint",
                 &serde_json::to_string(&update_key)?,
                 "sds",
             )

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -3,10 +3,16 @@ mod credential;
 mod datatypes;
 #[cfg(feature = "plugin-did-sidetree")]
 mod did;
+#[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+mod presentation;
+#[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+mod shared;
 mod version_info;
 
 #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
 pub(crate) use credential::{Credential, CredentialError};
 #[cfg(feature = "plugin-did-sidetree")]
 pub(crate) use did::Did;
+#[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+pub(crate) use presentation::{Presentation, PresentationError};
 pub(crate) use version_info::VersionInfo;

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -1,0 +1,168 @@
+use regex::Regex;
+use serde::de::DeserializeOwned;
+use std::collections::HashMap;
+
+use thiserror::Error;
+use vade_evan_bbs::{CredentialSchema, RequestProofPayload};
+
+use super::{
+    datatypes::DidDocumentResult,
+    shared::{convert_to_nquads, create_draft_credential_from_schema, SharedError},
+};
+use crate::api::VadeEvan;
+use crate::helpers::datatypes::EVAN_METHOD;
+
+#[derive(Error, Debug)]
+pub enum PresentationError {
+    #[error("internal VadeEvan call failed; {0}")]
+    VadeEvanError(String),
+    #[error("{0}")]
+    JsonLdHandling(#[from] SharedError), // for now only one type of error from shared helper, so just re-package it
+    #[error("could not find revealed attributes in nquads; {0}")]
+    InvalidRevealedAttributes(String),
+    #[error("internal error occurred; {0}")]
+    InternalError(String),
+    #[error("JSON (de)serialization failed")]
+    JsonDeSerialization(#[from] serde_json::Error),
+}
+
+// Master secret is always incorporated, without being mentioned in the credential schema
+const ADDITIONAL_HIDDEN_MESSAGES_COUNT: usize = 1;
+const NQUAD_REGEX: &str = r"^_:c14n0 <http://schema.org/([^>]+?)>";
+const TYPE_OPTIONS: &str = r#"{ "type": "bbs" }"#;
+
+pub struct Presentation<'a> {
+    vade_evan: &'a mut VadeEvan,
+}
+
+impl<'a> Presentation<'a> {
+    pub fn new(vade_evan: &'a mut VadeEvan) -> Result<Self, PresentationError> {
+        Ok(Self { vade_evan })
+    }
+
+    pub async fn create_proof_request(
+        &mut self,
+        schema_did: &str,
+        revealed_attributes: &[&str],
+    ) -> Result<String, PresentationError> {
+        let mut reveal_attributes = HashMap::new();
+        reveal_attributes.insert(schema_did.to_string(), revealed_attributes.to_vec());
+        let proof_request_payload = RequestProofPayload {
+            verifier_did: None,
+            schemas: vec![schema_did.to_string()],
+            reveal_attributes: self
+                .get_reveal_attributes_map(schema_did, revealed_attributes)
+                .await?,
+        };
+
+        let proof_request_json = serde_json::to_string(&proof_request_payload)?;
+
+        self.vade_evan
+            .vc_zkp_request_proof(EVAN_METHOD, TYPE_OPTIONS, &proof_request_json)
+            .await
+            .map_err(|err| PresentationError::VadeEvanError(err.to_string()))
+    }
+
+    async fn get_did_document<T>(&mut self, did: &str) -> Result<T, PresentationError>
+    where
+        T: DeserializeOwned,
+    {
+        let did_result_str = self
+            .vade_evan
+            .did_resolve(did)
+            .await
+            .map_err(|err| PresentationError::VadeEvanError(err.to_string()))?;
+        let did_result_value: DidDocumentResult<T> = serde_json::from_str(&did_result_str)?;
+
+        Ok(did_result_value.did_document)
+    }
+
+    async fn get_reveal_attributes_map(
+        &mut self,
+        schema_did: &str,
+        revealed_attributes: &[&str],
+    ) -> Result<HashMap<String, Vec<usize>>, PresentationError> {
+        let regex = Regex::new(NQUAD_REGEX).map_err(|err| {
+            PresentationError::InternalError(format!("regex for nquads invalid; {0}", &err))
+        })?;
+
+        // get nquads for schema
+        let schema: CredentialSchema = self.get_did_document(schema_did).await?;
+        let credential_draft =
+            create_draft_credential_from_schema(false, Some("did:placeholder"), schema);
+        let credential_draft_str = serde_json::to_string(&credential_draft)?;
+        let nquads = convert_to_nquads(&credential_draft_str).await?;
+
+        // avoid duplicated regex applications, so build property to index map beforehand
+        let mut name_to_index_map: HashMap<&str, usize> = HashMap::new();
+        for (index, nquad) in nquads.iter().enumerate() {
+            if let Some(captures) = regex.captures(nquad) {
+                if let Some(name_match) = captures.get(1) {
+                    name_to_index_map.insert(name_match.as_str(), index);
+                }
+            }
+        }
+
+        // collect indices for attributes we have and collect missing ones
+        let mut attribute_indices: Vec<usize> = vec![];
+        let mut missing_attributes: Vec<&str> = vec![];
+        for attribute_name in revealed_attributes.iter() {
+            if let Some(index) = name_to_index_map.get(attribute_name) {
+                attribute_indices.push(*index + ADDITIONAL_HIDDEN_MESSAGES_COUNT);
+            } else {
+                missing_attributes.push(attribute_name);
+            }
+        }
+
+        if missing_attributes.len() > 0 {
+            return Err(PresentationError::InvalidRevealedAttributes(
+                missing_attributes.join(", "),
+            ));
+        }
+
+        Ok(HashMap::from([(schema_did.to_string(), attribute_indices)]))
+    }
+}
+
+#[cfg(test)]
+mod tests_proof_request {
+
+    use anyhow::Result;
+    use vade_evan_bbs::BbsProofRequest;
+
+    use crate::{VadeEvan, DEFAULT_SIGNER, DEFAULT_TARGET};
+
+    // evan.address
+    const SCHEMA_DID: &str = "did:evan:EiBrPL8Yif5NWHOzbKvyh1PX1wKVlWvIa6nTG1v8PXytvg";
+
+    #[tokio::test]
+
+    async fn helper_can_create_proof_request() -> Result<()> {
+        let mut vade_evan = VadeEvan::new(crate::VadeEvanConfig {
+            target: DEFAULT_TARGET,
+            signer: DEFAULT_SIGNER,
+        })?;
+
+        let result = vade_evan
+            .helper_create_proof_request(SCHEMA_DID, &["zip", "country"])
+            .await;
+
+        assert!(result.is_ok());
+        let parsed: BbsProofRequest = serde_json::from_str(&result?)?;
+        assert_eq!(parsed.r#type, "BBS");
+        assert_eq!(parsed.sub_proof_requests[0].schema, SCHEMA_DID);
+        assert_eq!(parsed.sub_proof_requests[0].revealed_attributes, [16, 14]);
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests_create_presentation {
+    // will be added with further updates
+}
+
+#[cfg(test)]
+mod tests_verify_presentation {
+    // will be added with further updates
+}

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -137,17 +137,9 @@ impl<'a> Presentation<'a> {
 
         // get parsed schema and "clone" it due to move occurring below
         let schema: CredentialSchema = self.get_did_document(schema_did).await?;
-        let schema_clone: CredentialSchema = serde_json::from_str(
-            &serde_json::to_string(&schema)
-                .map_err(PresentationError::to_serialization_error("schema document"))?,
-        )
-        .map_err(PresentationError::to_deserialization_error(
-            "schema document",
-            &format!("document of {}", &schema_did),
-        ))?;
         // get nquads for schema
         let credential_draft =
-            create_draft_credential_from_schema(false, Some("did:placeholder"), schema);
+            create_draft_credential_from_schema(false, Some("did:placeholder"), &schema);
         let credential_draft_str = serde_json::to_string(&credential_draft).map_err(
             PresentationError::to_serialization_error("UnsignedBbsCredential"),
         )?;
@@ -163,13 +155,8 @@ impl<'a> Presentation<'a> {
             }
         }
 
-        let attribute_names = revealed_attributes.unwrap_or_else(|| {
-            schema_clone
-                .properties
-                .keys()
-                .map(|p| p.to_string())
-                .collect()
-        });
+        let attribute_names = revealed_attributes
+            .unwrap_or_else(|| schema.properties.keys().map(|p| p.to_string()).collect());
 
         // collect indices for attributes we have and collect missing ones
         let mut attribute_indices: Vec<usize> = vec![];

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -94,7 +94,7 @@ impl<'a> Presentation<'a> {
             verifier_did: None,
             schemas: vec![schema_did.to_string()],
             reveal_attributes: self
-                .get_reveal_attributes_map(schema_did, revealed_attributes_parsed)
+                .get_reveal_attributes_indices_map(schema_did, revealed_attributes_parsed)
                 .await?,
         };
 
@@ -136,7 +136,7 @@ impl<'a> Presentation<'a> {
         Ok(did_result_value.did_document)
     }
 
-    async fn get_reveal_attributes_map(
+    async fn get_reveal_attributes_indices_map(
         &mut self,
         schema_did: &str,
         revealed_attributes: Option<Vec<String>>,

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -197,6 +197,7 @@ impl<'a> Presentation<'a> {
 }
 
 #[cfg(test)]
+#[cfg(not(all(feature = "target-c-lib", feature = "capability-sdk")))]
 mod tests_proof_request {
 
     use anyhow::Result;

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -67,6 +67,16 @@ impl<'a> Presentation<'a> {
         Ok(Self { vade_evan })
     }
 
+    /// Requests a proof for a credential.
+    /// The proof request consists of the fields the verifier wants to be revealed per schema.
+    ///
+    /// # Arguments
+    ///
+    /// * `schema_did` - DID of schema to request proof for
+    /// * `revealed_attributes` - list of names of revealed attributes in specified schema, reveals all if omitted
+    ///
+    /// # Returns
+    /// * `Option<String>` - A `ProofRequest` as JSON
     pub async fn create_proof_request(
         &mut self,
         schema_did: &str,

--- a/src/helpers/shared.rs
+++ b/src/helpers/shared.rs
@@ -47,7 +47,7 @@ pub async fn convert_to_nquads(document_string: &str) -> Result<Vec<String>, Sha
 pub fn create_draft_credential_from_schema(
     use_valid_until: bool,
     subject_did: Option<&str>,
-    schema: CredentialSchema,
+    schema: &CredentialSchema,
 ) -> UnsignedBbsCredential {
     let credential = UnsignedBbsCredential {
         context: vec![
@@ -68,13 +68,14 @@ pub fn create_draft_credential_from_schema(
             id: subject_did.map(|s| s.to_owned()), // subject.id stays optional, defined by create_offer call
             data: schema // fill ALL subject data fields with empty string (mandatory and optional ones)
                 .properties
+                .clone()
                 .into_iter()
                 .map(|(name, _schema_property)| (name, String::new()))
                 .collect(),
         },
         credential_schema: CredentialSchemaReference {
-            id: schema.id,
-            r#type: schema.r#type,
+            id: schema.id.to_owned(),
+            r#type: schema.r#type.to_owned(),
         },
         credential_status: CredentialStatus {
             id: "did:evan:zkp:placeholder_status#0".to_string(),

--- a/src/helpers/shared.rs
+++ b/src/helpers/shared.rs
@@ -1,0 +1,87 @@
+use ssi::{
+    jsonld::{json_to_dataset, JsonLdOptions, StaticLoader},
+    urdna2015::normalize,
+};
+use thiserror::Error;
+use vade_evan_bbs::{
+    CredentialSchema,
+    CredentialSchemaReference,
+    CredentialStatus,
+    CredentialSubject,
+    UnsignedBbsCredential,
+};
+
+#[derive(Error, Debug)]
+pub enum SharedError {
+    #[error("JSON-ld handling failed, {0}")]
+    JsonLdHandling(String),
+}
+
+pub async fn convert_to_nquads(document_string: &str) -> Result<Vec<String>, SharedError> {
+    let mut loader = StaticLoader;
+    let options = JsonLdOptions {
+        base: None,           // -b, Base IRI
+        expand_context: None, // -c, IRI for expandContext option
+        ..Default::default()
+    };
+    let dataset = json_to_dataset(
+        &document_string,
+        None, // will be patched into @context, e.g. Some(&r#"["https://schema.org/"]"#.to_string()),
+        false,
+        Some(&options),
+        &mut loader,
+    )
+    .await
+    .map_err(|err| SharedError::JsonLdHandling(err.to_string()))?;
+    let dataset_normalized = normalize(&dataset).unwrap();
+    let normalized = dataset_normalized.to_nquads().unwrap();
+    let non_empty_lines = normalized
+        .split("\n")
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect();
+
+    Ok(non_empty_lines)
+}
+
+pub fn create_draft_credential_from_schema(
+    use_valid_until: bool,
+    subject_did: Option<&str>,
+    schema: CredentialSchema,
+) -> UnsignedBbsCredential {
+    let credential = UnsignedBbsCredential {
+        context: vec![
+            "https://www.w3.org/2018/credentials/v1".to_string(),
+            "https://schema.org/".to_string(),
+            "https://w3id.org/vc-revocation-list-2020/v1".to_string(),
+        ],
+        id: "uuid:834ca9da-9f09-4359-8264-c890de13cdc8".to_string(),
+        r#type: vec!["VerifiableCredential".to_string()],
+        issuer: "did:evan:testcore:placeholder_issuer".to_string(),
+        valid_until: if use_valid_until {
+            Some("2031-01-01T00:00:00.000Z".to_string())
+        } else {
+            None
+        },
+        issuance_date: "2021-01-01T00:00:00.000Z".to_string(),
+        credential_subject: CredentialSubject {
+            id: subject_did.map(|s| s.to_owned()), // subject.id stays optional, defined by create_offer call
+            data: schema // fill ALL subject data fields with empty string (mandatory and optional ones)
+                .properties
+                .into_iter()
+                .map(|(name, _schema_property)| (name, String::new()))
+                .collect(),
+        },
+        credential_schema: CredentialSchemaReference {
+            id: schema.id,
+            r#type: schema.r#type,
+        },
+        credential_status: CredentialStatus {
+            id: "did:evan:zkp:placeholder_status#0".to_string(),
+            r#type: "RevocationList2020Status".to_string(),
+            revocation_list_index: "0".to_string(),
+            revocation_list_credential: "did:evan:zkp:placeholder_status".to_string(),
+        },
+    };
+    credential
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -843,7 +843,7 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
             .long("operation")
             .value_name("operation")
             .required(true)
-            .help("Operation type AddKey/RemoveKey/AddServiceEnpoint/RemoveServiceEnpoint")
+            .help("Operation type AddKey/RemoveKey/AddServiceEndpoint/RemoveServiceEndpoint")
             .takes_value(true),
         "update_key" => Arg::with_name("update_key")
             .long("update_key")

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,7 +248,7 @@ async fn main() -> Result<()> {
                         get_argument_value(sub_m, "schema_did", None),
                         get_argument_value(sub_m, "credential_subject", None),
                         get_argument_value(sub_m, "bbs_secret", None),
-                        get_argument_value(sub_m, "bbs_private_key", None),
+                        get_argument_value(sub_m, "private_key", None),
                         get_argument_value(sub_m, "credential_revocation_did", None),
                         get_argument_value(sub_m, "credential_revocation_id", None),
                         get_optional_argument_value(sub_m, "exp_date"),
@@ -379,7 +379,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .arg(get_clap_argument("schema_did")?)
                     .arg(get_clap_argument("credential_subject")?)
                     .arg(get_clap_argument("bbs_secret")?)
-                    .arg(get_clap_argument("bbs_private_key")?)
+                    .arg(get_clap_argument("private_key")?)
                     .arg(get_clap_argument("credential_revocation_did")?)
                     .arg(get_clap_argument("credential_revocation_id")?)
                     .arg(get_clap_argument("exp_date")?)
@@ -833,6 +833,12 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
             .value_name("subject_did")
             .help("DID of subject")
             .takes_value(true),
+        "credential_subject" => Arg::with_name("credential_subject") // same as above, but mandatory
+            .long("credential_subject")
+            .value_name("credential_subject")
+            .required(true)
+            .help("DID of subject")
+            .takes_value(true),
         "operation" => Arg::with_name("operation")
             .long("operation")
             .value_name("operation")
@@ -876,6 +882,24 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
             .value_name("private_key")
             .required(true)
             .help("private key to be supplied for local signer")
+            .takes_value(true),
+        "credential_revocation_did" => Arg::with_name("credential_revocation_did")
+            .long("credential_revocation_did")
+            .value_name("credential_revocation_did")
+            .required(true)
+            .help("revocation list DID")
+            .takes_value(true),
+        "credential_revocation_id" => Arg::with_name("credential_revocation_id")
+            .long("credential_revocation_id")
+            .value_name("credential_revocation_id")
+            .required(true)
+            .help("index in revocation list")
+            .takes_value(true),
+        "exp_date" => Arg::with_name("exp_date")
+            .long("exp_date")
+            .value_name("exp_date")
+            .required(true)
+            .help(r#"expiration date, string, e.g. "1722-12-03T14:23:42.120Z""#)
             .takes_value(true),
         "revealed_attributes" => Arg::with_name("revealed_attributes")
             .long("revealed_attributes")

--- a/src/main.rs
+++ b/src/main.rs
@@ -261,7 +261,7 @@ async fn main() -> Result<()> {
                 get_vade_evan(sub_m)?
                     .helper_create_proof_request(
                         get_argument_value(sub_m, "schema_did", None),
-                        get_argument_value(sub_m, "revealed_attributes", None),
+                        get_optional_argument_value(sub_m, "revealed_attributes"),
                     )
                     .await?
             }
@@ -904,8 +904,7 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
         "revealed_attributes" => Arg::with_name("revealed_attributes")
             .long("revealed_attributes")
             .value_name("revealed_attributes")
-            .required(true)
-            .help("list of names of revealed attributes in specified schema")
+            .help("list of names of revealed attributes in specified schema, reveals all if omitted")
             .takes_value(true),
         _ => {
             bail!("invalid arg_name: '{}'", &arg_name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -256,6 +256,15 @@ async fn main() -> Result<()> {
                     .await?;
                 "".to_string()
             }
+            #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+            ("create_proof_request", Some(sub_m)) => {
+                get_vade_evan(sub_m)?
+                    .helper_create_proof_request(
+                        get_argument_value(sub_m, "schema_did", None),
+                        get_argument_value(sub_m, "revealed_attributes", None),
+                    )
+                    .await?
+            }
             _ => {
                 bail!("invalid subcommand");
             }
@@ -374,6 +383,17 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .arg(get_clap_argument("credential_revocation_did")?)
                     .arg(get_clap_argument("credential_revocation_id")?)
                     .arg(get_clap_argument("exp_date")?)
+            );
+        } else {}
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))] {
+            subcommand = subcommand.subcommand(
+                SubCommand::with_name("create_proof_request")
+                    .about("Requests a proof for a credential.")
+                    .arg(get_clap_argument("schema_did")?)
+                    .arg(get_clap_argument("revealed_attributes")?)
             );
         } else {}
     }
@@ -856,6 +876,12 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
             .value_name("private_key")
             .required(true)
             .help("private key to be supplied for local signer")
+            .takes_value(true),
+        "revealed_attributes" => Arg::with_name("revealed_attributes")
+            .long("revealed_attributes")
+            .value_name("revealed_attributes")
+            .required(true)
+            .help("list of names of revealed attributes in specified schema")
             .takes_value(true),
         _ => {
             bail!("invalid arg_name: '{}'", &arg_name);

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -293,6 +293,22 @@ cfg_if::cfg_if! {
                 .map_err(jsify_vade_evan_error)?;
             Ok("".to_string())
         }
+
+        #[cfg(all(feature = "plugin-vc-zkp-bbs", feature = "plugin-did-sidetree"))]
+        #[wasm_bindgen]
+        pub async fn helper_create_proof_request(
+            schema_did: String,
+            revealed_attributes: String,
+        ) -> Result<String, JsValue> {
+            let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
+            vade_evan
+                .helper_create_proof_request(
+                    &schema_did,
+                    &revealed_attributes,
+                ).await
+                .map_err(jsify_vade_evan_error)?;
+            Ok("".to_string())
+        }
     } else {
     }
 }

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -298,13 +298,13 @@ cfg_if::cfg_if! {
         #[wasm_bindgen]
         pub async fn helper_create_proof_request(
             schema_did: String,
-            revealed_attributes: String,
+            revealed_attributes: Option<String>,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
             vade_evan
                 .helper_create_proof_request(
                     &schema_did,
-                    &revealed_attributes,
+                    revealed_attributes.as_deref(),
                 ).await
                 .map_err(jsify_vade_evan_error)?;
             Ok("".to_string())


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Adds helper function to create proof requests from schema DID and a list of attribute names to be revealed.

## Details

<!--- HOW does it change stuff? -->

- add new impl in new `presentation` helper
- use an improved different handling for JSON (de)serialisation error handling, that might be applied to credential helper in the future as well, if it fits well
- fix smaller issues in existing helper functions