### PR TITLE
Fix wasm build and sdk release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,12 +143,12 @@ jobs:
         id: files
         with:
           cond: ${{ matrix.target == 'wasm32-unknown-unknown' }}
-          if_true: "release"
-          if_false: "release/libvade_evan.a"
+          if_true: pkg
+          if_false: target/${{ matrix.target }}/release/libvade_evan.a
       - name: Compress files
         uses: vimtor/action-zip@v1
         with:
-          files: target/${{ matrix.target }}/${{ steps.files.outputs.value }}
+          files: ${{ steps.files.outputs.value }}
           dest: target/${{ matrix.target }}.zip
       - name: Create Github Release
         uses: ncipollo/release-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ did-write = []
 vc-zkp = []
 
 # build for sdk integration with request list
-target-c-sdk = ["c-lib", "vade-sidetree/sdk", "did-substrate", "jwt-vc", "vc-zkp-bbs", "uuid"]
+target-c-sdk = ["c-lib", "vade-sidetree/sdk", "didcomm", "did-sidetree", "did-substrate", "jwt-vc", "vc-zkp-bbs"]
 
 # build for consuming vade-evan from C
 target-c-lib = ["c-lib", "default"]

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -27,6 +27,7 @@
 - add `payload` argument to did_create in CLI
 - align key format for master secrets and public keys (no extra double quotes)
 - fix optional params for did_create
+- fix wasm release and `target-c-sdk` build options
 
 ### Deprecation
 


### PR DESCRIPTION
## Descripton

Wasm release should contain pkg folder instead of release folder and target-c-sdk is missing some feature options.

## Details

- Fixed release.yml
- Added missing options to target-c-sdk
- update versions.md

