### PR TITLE
Remove credential subject

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4921,8 +4921,8 @@ dependencies = [
 
 [[package]]
 name = "vade-evan-bbs"
-version = "0.3.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/remove-credential-subject-id#1c524d4b259f6bee74f4efc71fe71542a62778b6"
+version = "0.4.0"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=develop#3a2a97efe81dd26ecfe3186ce5eb5c46171d1121"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4988,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "vade-jwt-vc"
 version = "0.2.0"
-source = "git+https://github.com/evannetwork/vade-jwt-vc.git?branch=feature/remove-credential-subject-id#ccd46c115641a1c437b9077487a32470a0cce2f6"
+source = "git+https://github.com/evannetwork/vade-jwt-vc.git?branch=develop#505e58b046a0e2f041dc2887e5a5a8a445778e16"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.3.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=develop#ba83a3f7c29251b2581e0b16bfb04bf2f2a4dcf7"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/remove-credential-subject-id#2f85c25dd412d1358a8ef223d0e31f95e63faacd"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -4974,8 +4974,7 @@ dependencies = [
 [[package]]
 name = "vade-jwt-vc"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99b7be7d18bc796039530baad8b901316e2a4142df853946dba09fdb51bbd2be"
+source = "git+https://github.com/evannetwork/vade-jwt-vc.git?branch=feature/remove-credential-subject-id#ccd46c115641a1c437b9077487a32470a0cce2f6"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ optional = true
 # jwt-vc
 [dependencies.vade-jwt-vc]
 git = "https://github.com/evannetwork/vade-jwt-vc.git"
-branch = "feature/remove-credential-subject-id"
+branch = "develop"
 version = "0.2.0"
 optional = true
 
@@ -146,8 +146,8 @@ optional = true
 
 [dependencies.vade-evan-bbs]
 git = "https://github.com/evannetwork/vade-evan-bbs.git"
-branch = "feature/remove-credential-subject-id"
-version = "0.3.0"
+branch = "develop"
+version = "0.4.0"
 optional = true
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,8 @@ optional = true
 
 # jwt-vc
 [dependencies.vade-jwt-vc]
+git = "https://github.com/evannetwork/vade-jwt-vc.git"
+branch = "feature/remove-credential-subject-id"
 version = "0.2.0"
 optional = true
 
@@ -144,7 +146,7 @@ optional = true
 
 [dependencies.vade-evan-bbs]
 git = "https://github.com/evannetwork/vade-evan-bbs.git"
-branch = "develop"
+branch = "feature/remove-credential-subject-id"
 version = "0.3.0"
 optional = true
 default-features = false

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cargo build --release --no-default-features --features target-java-lib
 ```
 - `target-wasm` - in combination with `wasm-pack`, build for usage in WASM (see below)
 ```sh
-wasm-pack build --release --target web -- --no-default-features --features=target-wasm
+wasm-pack build --release --target nodejs -- --no-default-features --features target-wasm
 ```
 
 One (and only one) target must be provided when building without default features.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -21,6 +21,7 @@
 - add `helper_create_presentation`
 - adjust `credential_status` property in `BbsCredential` to be optional
 - refactor features to use target specific(c-lib, c-sdk, wasm, cli, java) builds
+- adjust functions to remove `credential_subject.id` from `BbsCredential` and other types
 
 ### Fixes
 

--- a/src/api/vade_bundle.rs
+++ b/src/api/vade_bundle.rs
@@ -20,11 +20,7 @@ use vade_universal_resolver::VadeUniversalResolver;
 #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
 use crate::in3_request_list::ResolveHttpRequest;
 
-#[cfg(any(
-    feature = "vc-zkp-bbs",
-    feature = "jwt-vc",
-    feature = "did-substrate"
-))]
+#[cfg(any(feature = "vc-zkp-bbs", feature = "jwt-vc", feature = "did-substrate"))]
 fn get_signer(signer: &str) -> Box<dyn Signer> {
     if signer.starts_with("remote") {
         Box::new(RemoteSigner::new(
@@ -144,6 +140,6 @@ fn get_vade_sidetree(
         request_id,
         #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
         request_function_callback,
-        std::env::var("SIDETREE_API_URL").ok()
+        std::env::var("SIDETREE_API_URL").ok(),
     ))
 }

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -284,7 +284,6 @@ impl VadeEvan {
     /// * `schema_did` - schema to create the offer for
     /// * `use_valid_until` - true if `validUntil` will be present in credential
     /// * `issuer_did` - DID of issuer
-    /// * `subject_did` - DID of subject (or `None` no subject id is used)
     ///
     /// # Returns
     /// * credential offer as JSON serialized [`BbsCredentialOffer`](https://docs.rs/vade_evan_bbs/*/vade_evan_bbs/struct.BbsCredentialOffer.html)
@@ -298,7 +297,6 @@ impl VadeEvan {
     ///
     ///         const ISSUER_DID: &str = "did:evan:testcore:0x6240cedfc840579b7fdcd686bdc65a9a8c42dea6";
     ///         const SCHEMA_DID: &str = "did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw";
-    ///         const SUBJECT_DID: &str = "did:evan:testcore:0x67ce8b01b3b75a9ba4a1462139a1edaa0d2f539f";
     ///
     ///         async fn example() -> Result<()> {
     ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
@@ -307,7 +305,6 @@ impl VadeEvan {
     ///                     SCHEMA_DID,
     ///                     false,
     ///                     ISSUER_DID,
-    ///                     Some(SUBJECT_DID),
     ///                 )
     ///                 .await?;
     ///
@@ -324,11 +321,10 @@ impl VadeEvan {
         schema_did: &str,
         use_valid_until: bool,
         issuer_did: &str,
-        subject_did: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         let mut credential = Credential::new(self)?;
         credential
-            .create_credential_offer(schema_did, use_valid_until, issuer_did, subject_did)
+            .create_credential_offer(schema_did, use_valid_until, issuer_did)
             .await
             .map_err(|err| err.into())
     }
@@ -557,7 +553,7 @@ impl VadeEvan {
     ///         const SIGNER_PRIVATE_KEY: &str =
     ///         "dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106";
     ///         const MASTER_SECRET: &str = "QyRmu33oIQFNW+dSI5wex3u858Ra7yx5O1tsxJgQvu8=";
-    ///         
+    ///         const SUBJECT_DID: &str = "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA";
     ///         const SCHEMA_DID: &str = "did:evan:EiBrPL8Yif5NWHOzbKvyh1PX1wKVlWvIa6nTG1v8PXytvg"; // evan.address
     ///         const CREDENTIAL: &str = r###"{
     ///             "id": "uuid:70b7ec4e-f035-493e-93d3-2cf5be4c7f88",
@@ -610,6 +606,7 @@ impl VadeEvan {
     ///                   CREDENTIAL,
     ///                   MASTER_SECRET,
     ///                   SIGNER_PRIVATE_KEY,
+    ///                   SUBJECT_DID,
     ///                   None,
     ///                )
     ///                .await;
@@ -627,6 +624,7 @@ impl VadeEvan {
         credential_str: &str,
         master_secret: &str,
         signing_key: &str,
+        prover_did: &str,
         revealed_attributes: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         use crate::helpers::Presentation;
@@ -638,6 +636,7 @@ impl VadeEvan {
                 credential_str,
                 master_secret,
                 signing_key,
+                prover_did,
                 revealed_attributes,
             )
             .await
@@ -767,7 +766,7 @@ impl VadeEvan {
     ///                                                }"#;
     ///         const BBS_SECRET: &str = "GRsdzRB0pf/8MKP/ZBOM2BEV1A8DIDfmLh8T3b1hPKc=";
     ///         const BBS_PRIVATE_KEY: &str = "WWTZW8pkz35UnvsUCEsof2CJmNHaJQ/X+B5xjWcHr/I=";
-    ///
+    ///         const SUBJECT_DID: &str = "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA";
     ///         async fn example() -> Result<()> {
     ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
     ///             let offer_str = vade_evan
@@ -779,6 +778,7 @@ impl VadeEvan {
     ///                     Some("did:revoc:12345"),
     ///                     Some("1"),
     ///                     None,
+    ///                     SUBJECT_DID
     ///                 )
     ///                 .await?;
     ///
@@ -799,6 +799,7 @@ impl VadeEvan {
         credential_revocation_did: Option<&str>,
         credential_revocation_id: Option<&str>,
         exp_date: Option<&str>,
+        subject_did: &str,
     ) -> Result<String, VadeEvanError> {
         let mut credential = Credential::new(self)?;
         credential
@@ -810,6 +811,7 @@ impl VadeEvan {
                 credential_revocation_did,
                 credential_revocation_id,
                 exp_date,
+                subject_did,
             )
             .await
             .map_err(|err| err.into())

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -553,7 +553,7 @@ impl VadeEvan {
     ///         const SIGNER_PRIVATE_KEY: &str =
     ///         "dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106";
     ///         const MASTER_SECRET: &str = "QyRmu33oIQFNW+dSI5wex3u858Ra7yx5O1tsxJgQvu8=";
-    ///         const SUBJECT_DID: &str = "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA";
+    ///         const PROVER_DID: &str = "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA";
     ///         const SCHEMA_DID: &str = "did:evan:EiBrPL8Yif5NWHOzbKvyh1PX1wKVlWvIa6nTG1v8PXytvg"; // evan.address
     ///         const CREDENTIAL: &str = r###"{
     ///             "id": "uuid:70b7ec4e-f035-493e-93d3-2cf5be4c7f88",

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -285,7 +285,7 @@ impl VadeEvan {
     /// * `use_valid_until` - true if `validUntil` will be present in credential
     /// * `issuer_did` - DID of issuer
     /// * `is_credential_status_included` - true if credentialStatus is included in credential
-    /// 
+    ///
     /// # Returns
     /// * credential offer as JSON serialized [`BbsCredentialOffer`](https://docs.rs/vade_evan_bbs/*/vade_evan_bbs/struct.BbsCredentialOffer.html)
     /// # Example
@@ -327,7 +327,12 @@ impl VadeEvan {
     ) -> Result<String, VadeEvanError> {
         let mut credential = Credential::new(self)?;
         credential
-            .create_credential_offer(schema_did, use_valid_until, issuer_did, is_credential_status_included)
+            .create_credential_offer(
+                schema_did,
+                use_valid_until,
+                issuer_did,
+                is_credential_status_included,
+            )
             .await
             .map_err(|err| err.into())
     }

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -662,7 +662,7 @@ impl VadeEvan {
     ///         const SIGNER_PRIVATE_KEY: &str =
     ///         "dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106";
     ///         const MASTER_SECRET: &str = "QyRmu33oIQFNW+dSI5wex3u858Ra7yx5O1tsxJgQvu8=";
-    ///         
+    ///         const PROVER_DID: &str = "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA";
     ///         const SCHEMA_DID: &str = "did:evan:EiBrPL8Yif5NWHOzbKvyh1PX1wKVlWvIa6nTG1v8PXytvg"; // evan.address
     ///         const CREDENTIAL: &str = r###"{
     ///             "id": "uuid:70b7ec4e-f035-493e-93d3-2cf5be4c7f88",
@@ -715,6 +715,7 @@ impl VadeEvan {
     ///                   CREDENTIAL,
     ///                   MASTER_SECRET,
     ///                   SIGNER_PRIVATE_KEY,
+    ///                   PROVER_DID,
     ///                   None,
     ///                )
     ///                .await?;

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -606,7 +606,7 @@ impl VadeEvan {
     ///                   CREDENTIAL,
     ///                   MASTER_SECRET,
     ///                   SIGNER_PRIVATE_KEY,
-    ///                   SUBJECT_DID,
+    ///                   PROVER_DID,
     ///                   None,
     ///                )
     ///                .await;

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -542,7 +542,6 @@ pub extern "C" fn execute_vade(
                         arguments_vec.get(0).unwrap_or_else(|| &no_args),
                         use_valid_until,
                         arguments_vec.get(2).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(3).map(|v| v.as_str()),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)
@@ -635,6 +634,7 @@ pub extern "C" fn execute_vade(
                         arguments_vec.get(4).map(|v| v.as_str()),
                         arguments_vec.get(5).map(|v| v.as_str()),
                         arguments_vec.get(6).map(|v| v.as_str()),
+                        arguments_vec.get(7).unwrap_or_else(|| &no_args),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)
@@ -677,7 +677,8 @@ pub extern "C" fn execute_vade(
                         arguments_vec.get(1).unwrap_or_else(|| &no_args),
                         arguments_vec.get(2).unwrap_or_else(|| &no_args),
                         arguments_vec.get(3).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(4).map(|v| v.as_str()),
+                        arguments_vec.get(4).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(5).map(|v| v.as_str()),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -326,7 +326,7 @@ impl<'a> Credential<'a> {
     /// * `credential_revocation_did` - revocation list DID (or `None` if no revocation is used)
     /// * `credential_revocation_id` - index in revocation list (or `None` if no revocation is used)
     /// * `exp_date` - expiration date, string, e.g. "1722-12-03T14:23:42.120Z" (or `None` if no expiration date is used)
-    /// * `subject_did` - subject did for self issued credential 
+    /// * `subject_did` - subject did for self issued credential
     ///
     /// # Returns
     /// * credential as JSON serialized [`BbsCredential`](https://docs.rs/vade_evan_bbs/*/vade_evan_bbs/struct.BbsCredential.html)
@@ -1040,7 +1040,7 @@ mod tests {
                 Some("did:revoc:12345"),
                 Some("1"),
                 None,
-                subject_id
+                subject_id,
             )
             .await
         {
@@ -1083,7 +1083,7 @@ mod tests {
                 None,
                 None,
                 None,
-                subject_id                
+                subject_id,
             )
             .await
         {

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -462,19 +462,6 @@ impl<'a> Credential<'a> {
         Ok(result)
     }
 
-    // async fn create_empty_unsigned_credential(
-    //     &mut self,
-    //     schema_did: &str,
-    //     use_valid_until: bool,
-    // ) -> Result<UnsignedBbsCredential, CredentialError> {
-    //     let schema: CredentialSchema = self.get_did_document(schema_did).await?;
-
-    //     Ok(create_draft_credential_from_schema(
-    //         use_valid_until,
-    //         &schema,
-    //     ))
-    // }
-
     pub async fn get_did_document<T>(&mut self, did: &str) -> Result<T, CredentialError>
     where
         T: DeserializeOwned,

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -1062,7 +1062,6 @@ mod tests {
             signer: "remote|http://127.0.0.1:7070/key/sign",
         })?;
         let credential_subject_str = r#"{
-            "id": "did:evan:EiAOD3RUcQrRXNZIR8BIEXuGvixcUj667_5fdeX-Sp3PpA",
             "data": {
                 "email": "value@x.com"
             }

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -380,6 +380,7 @@ mod tests_proof_request {
         "revocationListCredential": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA"
     },
     "credentialSubject": {
+        "id": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
         "data": {
             "bio": "biography"
         }

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -685,6 +685,7 @@ mod tests_proof_request {
                 CREDENTIAL,
                 MASTER_SECRET,
                 SIGNER_PRIVATE_KEY,
+                SUBJECT_DID,
                 None,
             )
             .await;

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -63,7 +63,7 @@ impl PresentationError {
 
 // Master secret is always incorporated, without being mentioned in the credential schema
 const ADDITIONAL_HIDDEN_MESSAGES_COUNT: usize = 1;
-const NQUAD_REGEX: &str = r"^_:c14n0 <http://schema.org/([^>]+?)>";
+const NQUAD_REGEX: &str = r"^_:c14n[0-9]* <http://schema.org/([^>]+?)>";
 const TYPE_OPTIONS: &str = r#"{ "type": "bbs" }"#;
 
 pub struct Presentation<'a> {
@@ -125,6 +125,7 @@ impl<'a> Presentation<'a> {
     /// * `credential` - credential to be shared in presentation
     /// * `master_secret` - user's master secret
     /// * `signing_key` - users secp256k1 private signing key
+    /// * `prover_did` - did of prover/holder
     /// * `revealed_attributes` - list of names of revealed attributes in specified schema,
     ///
     /// # Returns
@@ -135,6 +136,7 @@ impl<'a> Presentation<'a> {
         credential_str: &str,
         master_secret: &str,
         signing_key: &str,
+        prover_did: &str,
         revealed_attributes: Option<&str>,
     ) -> Result<String, PresentationError> {
         let credential: BbsCredential = serde_json::from_str(credential_str).map_err(
@@ -212,11 +214,6 @@ impl<'a> Presentation<'a> {
         let revealed = credential.credential_subject.clone();
         revealed_properties_schema_map.insert(schema_did.to_owned(), revealed);
 
-        // get prover did
-        let prover = credential.credential_subject.id.clone().ok_or_else(|| {
-            PresentationError::InternalError("CredentialSubject doesn't contain did".to_owned())
-        })?;
-
         let mut helper_credential = Credential::new(self.vade_evan)
             .map_err(|err| PresentationError::InternalError(err.to_string()))?;
         let public_key_issuer = helper_credential
@@ -234,8 +231,8 @@ impl<'a> Presentation<'a> {
             public_key_schema_map,
             nquads_schema_map,
             master_secret: master_secret.to_owned(),
-            prover_did: prover.clone(),
-            prover_public_key_did: format!("{}#key-1", prover),
+            prover_did: prover_did.to_owned(),
+            prover_public_key_did: format!("{}#key-1", prover_did.to_owned()),
             prover_proving_key: signing_key.to_owned(),
         };
 
@@ -288,8 +285,7 @@ impl<'a> Presentation<'a> {
         // get parsed schema and "clone" it due to move occurring below
         let schema: CredentialSchema = self.get_did_document(schema_did).await?;
         // get nquads for schema
-        let credential_draft =
-            create_draft_credential_from_schema(false, Some("did:placeholder"), &schema);
+        let credential_draft = create_draft_credential_from_schema(false, &schema);
         let credential_draft_str = serde_json::to_string(&credential_draft).map_err(
             PresentationError::to_serialization_error("UnsignedBbsCredential"),
         )?;
@@ -351,44 +347,45 @@ mod tests_proof_request {
     const NOT_FOUND_DID: &str = "did:evan:EiBrPL8Yif5NWHOzbKvyh1PX1wKVlWvIa6nTG1v8PXytvgfoobar";
     const SCHEMA_DID: &str = "did:evan:EiBrPL8Yif5NWHOzbKvyh1PX1wKVlWvIa6nTG1v8PXytvg"; // evan.address
     const SCHEMA_DID_2: &str = "did:evan:EiCimsy3uWJ7PivWK0QUYSCkImQnjrx6fGr6nK8XIg26Kg";
+    const SUBJECT_DID: &str = "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA";
     const CREDENTIAL: &str = r###"{
-        "id": "uuid:70b7ec4e-f035-493e-93d3-2cf5be4c7f88",
-        "type": [
-            "VerifiableCredential"
-        ],
-        "proof": {
-            "type": "BbsBlsSignature2020",
-            "created": "2023-02-01T14:08:17.000Z",
-            "signature": "kvSyi40dnZ5S3/mSxbSUQGKLpyMXDQNLCPtwDGM9GsnNNKF7MtaFHXIbvXaVXku0EY/n2uNMQ2bmK2P0KEmzgbjRHtzUOWVdfAnXnVRy8/UHHIyJR471X6benfZk8KG0qVqy+w67z9g628xRkFGA5Q==",
-            "proofPurpose": "assertionMethod",
-            "verificationMethod": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA#bbs-key-1",
-            "credentialMessageCount": 13,
-            "requiredRevealStatements": []
-        },
-        "issuer": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
-        "@context": [
-            "https://www.w3.org/2018/credentials/v1",
-            "https://schema.org/",
-            "https://w3id.org/vc-revocation-list-2020/v1"
-        ],
-        "issuanceDate": "2023-02-01T14:08:09.849Z",
-        "credentialSchema": {
-            "id": "did:evan:EiCimsy3uWJ7PivWK0QUYSCkImQnjrx6fGr6nK8XIg26Kg",
-            "type": "EvanVCSchema"
-        },
-        "credentialStatus": {
-            "id": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA#4",
-            "type": "RevocationList2020Status",
-            "revocationListIndex": "4",
-            "revocationListCredential": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA"
-        },
-        "credentialSubject": {
-            "id": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
-            "data": {
-                "bio": "biography"
-            }
+    "id": "uuid:70b7ec4e-f035-493e-93d3-2cf5be4c7f88",
+    "type": [
+        "VerifiableCredential"
+    ],
+    "proof": {
+        "type": "BbsBlsSignature2020",
+        "created": "2023-02-01T14:08:17.000Z",
+        "signature": "kvSyi40dnZ5S3/mSxbSUQGKLpyMXDQNLCPtwDGM9GsnNNKF7MtaFHXIbvXaVXku0EY/n2uNMQ2bmK2P0KEmzgbjRHtzUOWVdfAnXnVRy8/UHHIyJR471X6benfZk8KG0qVqy+w67z9g628xRkFGA5Q==",
+        "proofPurpose": "assertionMethod",
+        "verificationMethod": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA#bbs-key-1",
+        "credentialMessageCount": 13,
+        "requiredRevealStatements": []
+    },
+    "issuer": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
+    "@context": [
+        "https://www.w3.org/2018/credentials/v1",
+        "https://schema.org/",
+        "https://w3id.org/vc-revocation-list-2020/v1"
+    ],
+    "issuanceDate": "2023-02-01T14:08:09.849Z",
+    "credentialSchema": {
+        "id": "did:evan:EiCimsy3uWJ7PivWK0QUYSCkImQnjrx6fGr6nK8XIg26Kg",
+        "type": "EvanVCSchema"
+    },
+    "credentialStatus": {
+        "id": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA#4",
+        "type": "RevocationList2020Status",
+        "revocationListIndex": "4",
+        "revocationListCredential": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA"
+    },
+    "credentialSubject": {
+        "id": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
+        "data": {
+            "bio": "biography"
         }
-    }"###;
+    }
+}"###;
     #[tokio::test]
     async fn helper_can_create_proof_request() -> Result<()> {
         let mut vade_evan = VadeEvan::new(crate::VadeEvanConfig {
@@ -406,7 +403,7 @@ mod tests_proof_request {
         assert_eq!(parsed.r#type, "BBS");
         assert_eq!(parsed.sub_proof_requests[0].schema, SCHEMA_DID);
         parsed.sub_proof_requests[0].revealed_attributes.sort();
-        assert_eq!(parsed.sub_proof_requests[0].revealed_attributes, [14, 16],);
+        assert_eq!(parsed.sub_proof_requests[0].revealed_attributes, [13, 15],);
 
         Ok(())
     }
@@ -496,7 +493,7 @@ mod tests_proof_request {
         parsed.sub_proof_requests[0].revealed_attributes.sort();
         assert_eq!(
             parsed.sub_proof_requests[0].revealed_attributes,
-            [12, 13, 14, 15, 16],
+            [11, 12, 13, 14, 15],
         );
 
         Ok(())
@@ -520,7 +517,10 @@ mod tests_proof_request {
         assert_eq!(parsed.r#type, "BBS");
         assert_eq!(parsed.sub_proof_requests[0].schema, SCHEMA_DID_2);
         parsed.sub_proof_requests[0].revealed_attributes.sort();
-        assert_eq!(parsed.sub_proof_requests[0].revealed_attributes, [12],);
+        assert_eq!(
+            parsed.sub_proof_requests[0].revealed_attributes,
+            [12],
+        );
 
         let presentation_result = presentation
             .create_presentation(
@@ -528,6 +528,7 @@ mod tests_proof_request {
                 CREDENTIAL,
                 MASTER_SECRET,
                 SIGNER_PRIVATE_KEY,
+                SUBJECT_DID,
                 None,
             )
             .await;
@@ -554,6 +555,7 @@ mod tests_proof_request {
                 CREDENTIAL,
                 MASTER_SECRET,
                 SIGNER_PRIVATE_KEY,
+                SUBJECT_DID,
                 None,
             )
             .await;

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -488,7 +488,7 @@ mod tests_proof_request {
            ],
            "signature":"sZTYWUrmYaVDUGs1L2UM/7f7UlVLSQS2vPQQG1YWU3TQRlcviNXFDx054zztzG8rWc1lw5e+SJNo4c1x+rpOFiXBjjK6IukN3a0zG5c/ayFbIQ6OVjxV7noWX8aTdNXNO5eyVV2Upd1YB4WGAuUO0w=="
         }
-     }"###;
+    }"###;
     #[tokio::test]
     async fn helper_can_create_proof_request() -> Result<()> {
         let mut vade_evan = VadeEvan::new(crate::VadeEvanConfig {

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -380,7 +380,6 @@ mod tests_proof_request {
         "revocationListCredential": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA"
     },
     "credentialSubject": {
-        "id": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
         "data": {
             "bio": "biography"
         }

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -517,10 +517,7 @@ mod tests_proof_request {
         assert_eq!(parsed.r#type, "BBS");
         assert_eq!(parsed.sub_proof_requests[0].schema, SCHEMA_DID_2);
         parsed.sub_proof_requests[0].revealed_attributes.sort();
-        assert_eq!(
-            parsed.sub_proof_requests[0].revealed_attributes,
-            [12],
-        );
+        assert_eq!(parsed.sub_proof_requests[0].revealed_attributes, [12],);
 
         let presentation_result = presentation
             .create_presentation(

--- a/src/helpers/shared.rs
+++ b/src/helpers/shared.rs
@@ -46,7 +46,6 @@ pub async fn convert_to_nquads(document_string: &str) -> Result<Vec<String>, Sha
 
 pub fn create_draft_credential_from_schema(
     use_valid_until: bool,
-    subject_did: Option<&str>,
     schema: &CredentialSchema,
 ) -> UnsignedBbsCredential {
     let credential = UnsignedBbsCredential {
@@ -65,7 +64,6 @@ pub fn create_draft_credential_from_schema(
         },
         issuance_date: "2021-01-01T00:00:00.000Z".to_string(),
         credential_subject: CredentialSubject {
-            id: subject_did.map(|s| s.to_owned()), // subject.id stays optional, defined by create_offer call
             data: schema // fill ALL subject data fields with empty string (mandatory and optional ones)
                 .properties
                 .clone()

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,16 +178,17 @@ async fn main() -> Result<()> {
                     Some(value) => value.to_lowercase() == "true",
                     None => false,
                 };
-                let include_credential_status =  match get_optional_argument_value(sub_m, "include_credential_status") {
-                    Some(value) => value.to_lowercase() == "true",
-                    None => false,
-                };
+                let include_credential_status =
+                    match get_optional_argument_value(sub_m, "include_credential_status") {
+                        Some(value) => value.to_lowercase() == "true",
+                        None => false,
+                    };
                 get_vade_evan(sub_m)?
                     .helper_create_credential_offer(
                         get_argument_value(sub_m, "schema_did", None),
                         use_valid_until,
                         get_argument_value(sub_m, "issuer_did", None),
-                        include_credential_status
+                        include_credential_status,
                     )
                     .await?
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,6 @@ async fn main() -> Result<()> {
                         get_argument_value(sub_m, "schema_did", None),
                         use_valid_until,
                         get_argument_value(sub_m, "issuer_did", None),
-                        get_optional_argument_value(sub_m, "subject_did"),
                     )
                     .await?
             }
@@ -254,6 +253,7 @@ async fn main() -> Result<()> {
                         get_optional_argument_value(sub_m, "credential_revocation_did"),
                         get_optional_argument_value(sub_m, "credential_revocation_id"),
                         get_optional_argument_value(sub_m, "exp_date"),
+                        get_argument_value(sub_m, "subject_did", None),
                     )
                     .await?;
                 "".to_string()
@@ -275,6 +275,7 @@ async fn main() -> Result<()> {
                         get_argument_value(sub_m, "credential", None),
                         get_argument_value(sub_m, "master_secret", None),
                         get_argument_value(sub_m, "private_key", None),
+                        get_argument_value(sub_m, "subject_did", None),
                         get_optional_argument_value(sub_m, "revealed_attributes"),
                     )
                     .await?
@@ -312,7 +313,6 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .arg(get_clap_argument("schema_did")?)
                     .arg(get_clap_argument("use_valid_until")?)
                     .arg(get_clap_argument("issuer_did")?)
-                    .arg(get_clap_argument("subject_did")?),
             );
         } else {}
     }
@@ -399,6 +399,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .arg(get_clap_argument("credential_revocation_did")?)
                     .arg(get_clap_argument("credential_revocation_id")?)
                     .arg(get_clap_argument("exp_date")?)
+                    .arg(get_clap_argument("subject_did")?)
             );
         } else {}
     }
@@ -422,6 +423,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .arg(get_clap_argument("credential")?)
                     .arg(get_clap_argument("master_secret")?)
                     .arg(get_clap_argument("private_key")?)
+                    .arg(get_clap_argument("subject_did")?)
                     .arg(get_clap_argument("revealed_attributes")?)
             );
         } else {}
@@ -860,7 +862,8 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
         "subject_did" => Arg::with_name("subject_did")
             .long("subject_did")
             .value_name("subject_did")
-            .help("DID of subject")
+            .required(true)
+            .help("DID of subject/holder/prover")
             .takes_value(true),
         "credential_subject" => Arg::with_name("credential_subject") // same as above, but mandatory
             .long("credential_subject")

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -143,6 +143,7 @@ struct HelperCreateSelfIssuedCredentialPayload {
     pub credential_revocation_did: Option<String>,
     pub credential_revocation_id: Option<String>,
     pub exp_date: Option<String>,
+    pub subject_did: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -159,6 +160,7 @@ struct HelperCreatePresentationPayload {
     pub credential_str: String,
     pub master_secret: String,
     pub signing_key: String,
+    pub prover_did: String,
     pub revealed_attributes: Option<String>,
 }
 
@@ -647,7 +649,6 @@ pub async fn execute_vade(
                         payload.schema_did,
                         payload.use_valid_until,
                         payload.issuer_did,
-                        payload.subject_did,
                         payload.is_credential_status_included,
                     ).await,
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
@@ -706,6 +707,7 @@ pub async fn execute_vade(
                         payload.credential_revocation_did,
                         payload.credential_revocation_id,
                         payload.exp_date,
+                        payload.subject_did
                     ).await,
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
@@ -732,6 +734,7 @@ pub async fn execute_vade(
                         payload.credential_str,
                         payload.master_secret,
                         payload.signing_key,
+                        payload.prover_did,
                         payload.revealed_attributes,
                     ).await,
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -431,62 +431,72 @@ pub async fn execute_vade(
 ) -> String {
     let result: Result<String, JsValue> = match func_name.as_str() {
         #[cfg(feature = "did-read")]
-        "did_resolve" =>
-            did_resolve(did_or_method, config).await,
+        "did_resolve" => did_resolve(did_or_method, config).await,
         #[cfg(feature = "did-write")]
-        "did_create" =>
-            did_create(did_or_method, options, payload, config).await,
+        "did_create" => did_create(did_or_method, options, payload, config).await,
         #[cfg(feature = "did-write")]
-        "did_update" =>
-            did_update(did_or_method, options, payload, config).await,
+        "did_update" => did_update(did_or_method, options, payload, config).await,
 
         #[cfg(feature = "didcomm")]
-        "didcomm_receive" =>
-            didcomm_receive(options, payload, config).await,
+        "didcomm_receive" => didcomm_receive(options, payload, config).await,
         #[cfg(feature = "didcomm")]
-        "didcomm_send" =>
-            didcomm_send(options, payload, config).await,
+        "didcomm_send" => didcomm_send(options, payload, config).await,
 
         #[cfg(feature = "vc-zkp-bbs")]
-        "run_custom_function" =>
-            run_custom_function(did_or_method, custom_func_name, options, payload, config).await,
+        "run_custom_function" => {
+            run_custom_function(did_or_method, custom_func_name, options, payload, config).await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_create_credential_offer" =>
-            vc_zkp_create_credential_offer(did_or_method, options, payload, config).await,
+        "vc_zkp_create_credential_offer" => {
+            vc_zkp_create_credential_offer(did_or_method, options, payload, config).await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_create_credential_proposal" =>
-            vc_zkp_create_credential_proposal(did_or_method, options, payload, config).await,
+        "vc_zkp_create_credential_proposal" => {
+            vc_zkp_create_credential_proposal(did_or_method, options, payload, config).await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_create_credential_schema" =>
-            vc_zkp_create_credential_schema(did_or_method, options, payload, config).await,
+        "vc_zkp_create_credential_schema" => {
+            vc_zkp_create_credential_schema(did_or_method, options, payload, config).await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_create_revocation_registry_definition" =>
-            vc_zkp_create_revocation_registry_definition(did_or_method, options, payload, config).await,
+        "vc_zkp_create_revocation_registry_definition" => {
+            vc_zkp_create_revocation_registry_definition(did_or_method, options, payload, config)
+                .await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_update_revocation_registry" =>
-            vc_zkp_update_revocation_registry(did_or_method, options, payload, config).await,
+        "vc_zkp_update_revocation_registry" => {
+            vc_zkp_update_revocation_registry(did_or_method, options, payload, config).await
+        }
         #[cfg(any(feature = "vc-zkp-bbs", feature = "vc-jwt"))]
-        "vc_zkp_issue_credential" =>
-            vc_zkp_issue_credential(did_or_method, options, payload, config).await,
+        "vc_zkp_issue_credential" => {
+            vc_zkp_issue_credential(did_or_method, options, payload, config).await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_finish_credential" =>
-            vc_zkp_finish_credential(did_or_method, options, payload, config).await,
+        "vc_zkp_finish_credential" => {
+            vc_zkp_finish_credential(did_or_method, options, payload, config).await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_present_proof" =>
-            vc_zkp_present_proof(did_or_method, options, payload, config).await,
+        "vc_zkp_present_proof" => {
+            vc_zkp_present_proof(did_or_method, options, payload, config).await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_request_credential" =>
-            vc_zkp_request_credential(did_or_method, options, payload, config).await,
+        "vc_zkp_request_credential" => {
+            vc_zkp_request_credential(did_or_method, options, payload, config).await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_request_proof" =>
-            vc_zkp_request_proof(did_or_method, options, payload, config).await,
+        "vc_zkp_request_proof" => {
+            vc_zkp_request_proof(did_or_method, options, payload, config).await
+        }
         #[cfg(feature = "vc-zkp-bbs")]
-        "vc_zkp_revoke_credential" =>
-            vc_zkp_revoke_credential(did_or_method, options, payload, config).await,
+        "vc_zkp_revoke_credential" => {
+            vc_zkp_revoke_credential(did_or_method, options, payload, config).await
+        }
         #[cfg(any(feature = "vc-zkp-bbs", feature = "vc-jwt"))]
-        "vc_zkp_verify_proof" =>
-            vc_zkp_verify_proof(did_or_method, options, payload, config).await,
-        _ => Err(JsValue::from(format!("invalid command for execute_vade: {}", &func_name))),
+        "vc_zkp_verify_proof" => vc_zkp_verify_proof(did_or_method, options, payload, config).await,
+        _ => Err(JsValue::from(format!(
+            "invalid command for execute_vade: {}",
+            &func_name
+        ))),
     };
 
     let response = match result {

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -203,7 +203,6 @@ cfg_if::cfg_if! {
             schema_did: String,
             use_valid_until: bool,
             issuer_did: String,
-            subject_did: Option<String>,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
             let offer = vade_evan
@@ -211,7 +210,6 @@ cfg_if::cfg_if! {
                     &schema_did,
                     use_valid_until,
                     &issuer_did,
-                    subject_did.as_deref(),
                 ).await
                 .map_err(jsify_vade_evan_error)?;
             Ok(offer)
@@ -282,6 +280,7 @@ cfg_if::cfg_if! {
             credential_revocation_did: Option<String>,
             credential_revocation_id: Option<String>,
             exp_date: Option<String>,
+            subject_did: String,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
             vade_evan
@@ -293,6 +292,7 @@ cfg_if::cfg_if! {
                     credential_revocation_did.as_deref(),
                     credential_revocation_id.as_deref(),
                     exp_date.as_deref(),
+                    &subject_did,
                 ).await
                 .map_err(jsify_vade_evan_error)?;
             Ok("".to_string())
@@ -321,6 +321,7 @@ cfg_if::cfg_if! {
             credential_str: String,
             master_secret: String,
             signing_key: String,
+            prover_did: String,
             revealed_attributes: Option<String>,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
@@ -330,6 +331,7 @@ cfg_if::cfg_if! {
                     &credential_str,
                     &master_secret,
                     &signing_key,
+                    &prover_did,
                     revealed_attributes.as_deref(),
                 ).await
                 .map_err(jsify_vade_evan_error)?;

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -16,7 +16,10 @@
 
 use crate::api::{VadeEvan, VadeEvanConfig, VadeEvanError, DEFAULT_SIGNER, DEFAULT_TARGET};
 use console_log;
-use serde::{de::DeserializeOwned, {Deserialize, Serialize}};
+use serde::{
+    de::DeserializeOwned,
+    {Deserialize, Serialize},
+};
 use std::{collections::HashMap, error::Error};
 use wasm_bindgen::prelude::*;
 
@@ -78,7 +81,6 @@ macro_rules! create_function {
     };
 }
 
-
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct HelperDidCreatePayload {
@@ -115,7 +117,7 @@ struct HelperCreateCredentialRequestPayload {
     pub bbs_secret: String,
     pub credential_values: String,
     pub credential_offer: String,
-    pub credential_schema: String
+    pub credential_schema: String,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -187,11 +189,17 @@ pub fn set_log_level(log_level: String) {
     };
 }
 
-fn get_parsing_error_message(error: &serde_json::Error, payload: &str,) -> JsValue {
-    return JsValue::from(format!(r#"got error \{}" when parsing payload: {}"#, &error, &payload))
+fn get_parsing_error_message(error: &serde_json::Error, payload: &str) -> JsValue {
+    return JsValue::from(format!(
+        r#"got error \{}" when parsing payload: {}"#,
+        &error, &payload
+    ));
 }
 
-fn parse<T>(payload: &str) -> Result<T, serde_json::Error> where T: DeserializeOwned {
+fn parse<T>(payload: &str) -> Result<T, serde_json::Error>
+where
+    T: DeserializeOwned,
+{
     serde_json::from_str(payload)
 }
 
@@ -611,23 +619,21 @@ pub async fn execute_vade(
             vc_zkp_revoke_credential(did_or_method, options, payload, config).await
         }
         #[cfg(any(feature = "vc-zkp-bbs", feature = "vc-jwt"))]
-        "vc_zkp_verify_proof" => {
-            vc_zkp_verify_proof(did_or_method, options, payload, config).await
-        }
+        "vc_zkp_verify_proof" => vc_zkp_verify_proof(did_or_method, options, payload, config).await,
 
         #[cfg(feature = "did-sidetree")]
         "helper_did_create" => {
             let payload_result = parse::<HelperDidCreatePayload>(&payload);
             match payload_result {
-                Ok(payload) =>
-                    helper_did_create(
-                        payload.bbs_public_key,
-                        payload.signing_key,
-                        payload.service_endpoint,
-                        payload.update_key,
-                        payload.recovery_key,
-                    ).await
-                    .map(none_to_empty_string),
+                Ok(payload) => helper_did_create(
+                    payload.bbs_public_key,
+                    payload.signing_key,
+                    payload.service_endpoint,
+                    payload.update_key,
+                    payload.recovery_key,
+                )
+                .await
+                .map(none_to_empty_string),
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -635,14 +641,14 @@ pub async fn execute_vade(
         "helper_did_update" => {
             let payload_result = parse::<HelperDidUpdatePayload>(&payload);
             match payload_result {
-                Ok(payload) =>
-                    helper_did_update(
-                        payload.did,
-                        payload.operation,
-                        payload.update_key,
-                        payload.payload
-                    ).await
-                    .map(none_to_empty_string),
+                Ok(payload) => helper_did_update(
+                    payload.did,
+                    payload.operation,
+                    payload.update_key,
+                    payload.payload,
+                )
+                .await
+                .map(none_to_empty_string),
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -651,13 +657,15 @@ pub async fn execute_vade(
         "helper_create_credential_offer" => {
             let payload_result = parse::<HelperCreateCredentialOfferPayload>(&payload);
             match payload_result {
-                Ok(payload) =>
+                Ok(payload) => {
                     helper_create_credential_offer(
                         payload.schema_did,
                         payload.use_valid_until,
                         payload.issuer_did,
                         payload.is_credential_status_included,
-                    ).await,
+                    )
+                    .await
+                }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -665,14 +673,16 @@ pub async fn execute_vade(
         "helper_create_credential_request" => {
             let payload_result = parse::<HelperCreateCredentialRequestPayload>(&payload);
             match payload_result {
-                Ok(payload) =>
+                Ok(payload) => {
                     helper_create_credential_request(
                         payload.issuer_public_key,
                         payload.bbs_secret,
                         payload.credential_values,
                         payload.credential_offer,
                         payload.credential_schema,
-                    ).await,
+                    )
+                    .await
+                }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -680,12 +690,14 @@ pub async fn execute_vade(
         "helper_revoke_credential" => {
             let payload_result = parse::<HelperRevokeCredentialPayload>(&payload);
             match payload_result {
-                Ok(payload) =>
+                Ok(payload) => {
                     helper_revoke_credential(
                         payload.credential,
                         payload.update_key_jwk,
                         payload.private_key,
-                    ).await,
+                    )
+                    .await
+                }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -693,11 +705,9 @@ pub async fn execute_vade(
         "helper_verify_credential" => {
             let payload_result = parse::<HelperVerifyCredentialPayload>(&payload);
             match payload_result {
-                Ok(payload) =>
-                    helper_verify_credential(
-                        payload.credential,
-                        payload.master_secret,
-                    ).await,
+                Ok(payload) => {
+                    helper_verify_credential(payload.credential, payload.master_secret).await
+                }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -705,7 +715,7 @@ pub async fn execute_vade(
         "helper_create_self_issued_credential" => {
             let payload_result = parse::<HelperCreateSelfIssuedCredentialPayload>(&payload);
             match payload_result {
-                Ok(payload) =>
+                Ok(payload) => {
                     helper_create_self_issued_credential(
                         payload.schema_did,
                         payload.credential_subject_str,
@@ -714,8 +724,10 @@ pub async fn execute_vade(
                         payload.credential_revocation_did,
                         payload.credential_revocation_id,
                         payload.exp_date,
-                        payload.subject_did
-                    ).await,
+                        payload.subject_did,
+                    )
+                    .await
+                }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -723,11 +735,10 @@ pub async fn execute_vade(
         "helper_create_proof_request" => {
             let payload_result = parse::<HelperCreateProofRequestPayload>(&payload);
             match payload_result {
-                Ok(payload) =>
-                    helper_create_proof_request(
-                        payload.schema_did,
-                        payload.revealed_attributes,
-                    ).await,
+                Ok(payload) => {
+                    helper_create_proof_request(payload.schema_did, payload.revealed_attributes)
+                        .await
+                }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -735,7 +746,7 @@ pub async fn execute_vade(
         "helper_create_presentation" => {
             let payload_result = parse::<HelperCreatePresentationPayload>(&payload);
             match payload_result {
-                Ok(payload) =>
+                Ok(payload) => {
                     helper_create_presentation(
                         payload.proof_request_str,
                         payload.credential_str,
@@ -743,7 +754,9 @@ pub async fn execute_vade(
                         payload.signing_key,
                         payload.prover_did,
                         payload.revealed_attributes,
-                    ).await,
+                    )
+                    .await
+                }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -751,16 +764,18 @@ pub async fn execute_vade(
         "helper_verify_presentation" => {
             let payload_result = parse::<HelperVerifyPresentationPayload>(&payload);
             match payload_result {
-                Ok(payload) =>
-                  helper_verify_presentation(
-                        payload.presentation_str,
-                        payload.proof_request_str,
-                    ).await,
+                Ok(payload) => {
+                    helper_verify_presentation(payload.presentation_str, payload.proof_request_str)
+                        .await
+                }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
 
-        _ => Err(JsValue::from(format!("invalid command for execute_vade: {}", &func_name)))
+        _ => Err(JsValue::from(format!(
+            "invalid command for execute_vade: {}",
+            &func_name
+        ))),
     };
 
     let response = match result {


### PR DESCRIPTION
## Descripton

credential_subject.id  has been removed from vade-evan-bbs and vade-jwt-vc , the functions and payloads need to be updated to reflect the change.

## Details

- Add subject_id param to helper functions where subject_did is required
- Adjust payload to functions where subject_did is passed
- Adjust test cases
- Update c-lib, wasm, cli bindings 