### PR TITLE
Remove waitForCompletion for sdk build

### DIFF
--- a/src/helpers/datatypes/did_types.rs
+++ b/src/helpers/datatypes/did_types.rs
@@ -16,7 +16,9 @@
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 
-#[cfg(feature = "did-sidetree")]
+#[cfg(all(feature = "did-sidetree", feature = "target-c-sdk"))]
+pub const TYPE_SIDETREE_OPTIONS: &str = r#"{ "type": "sidetree", "waitForCompletion":false }"#;
+#[cfg(all(feature = "did-sidetree", not(feature = "target-c-sdk")))]
 pub const TYPE_SIDETREE_OPTIONS: &str = r#"{ "type": "sidetree", "waitForCompletion":true }"#;
 #[allow(dead_code)]
 pub const EVAN_METHOD: &str = "did:evan";


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Removes `waitForCompletion` for sdk build to avoid polling same data over and over and running into an error.

## Details

<!--- HOW does it change stuff? -->

- as requests are cashed when run with SDK in C, waitForCompletion would just try to fetch the same data over and over until running into a timeout
- therefore `waitForCompletion` is now deactivated for C-SDK build
