### PR TITLE
Adjust vade to create presentation without proof

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -31,6 +31,7 @@
 - adjust functions to remove `credential_subject.id` from `BbsCredential` and other types
 - add `helper_verify_presentation`
 - add support for `required_reveal_statements` in `vade-evan-bbs`
+- add helper function `helper_create_self_issued_presentation` function
 
 ### Fixes
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -655,6 +655,79 @@ impl VadeEvan {
             .map_err(|err| err.into())
     }
 
+    /// Creates a self issued presention.
+    /// The presentation doesn't contain proof.
+    ///
+    /// # Arguments
+    ///
+    /// * `unsigned_credential` - unsigned_credential to be shared in presentation
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// cfg_if::cfg_if! {
+    ///     if #[cfg(not(all(feature = "c-lib", feature = "target-c-sdk")))] {
+    ///         use anyhow::Result;
+    ///         use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
+    ///         const UNSIGNED_CREDENTIAL: &str = r###"{
+    ///             "id": "uuid:70b7ec4e-f035-493e-93d3-2cf5be4c7f88",
+    ///             "type": [
+    ///                 "VerifiableCredential"
+    ///             ],
+    ///             "issuer": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
+    ///             "@context": [
+    ///                 "https://www.w3.org/2018/credentials/v1",
+    ///                 "https://schema.org/",
+    ///                 "https://w3id.org/vc-revocation-list-2020/v1"
+    ///             ],
+    ///             "issuanceDate": "2023-02-01T14:08:09.849Z",
+    ///             "credentialSchema": {
+    ///                 "id": "did:evan:EiCimsy3uWJ7PivWK0QUYSCkImQnjrx6fGr6nK8XIg26Kg",
+    ///                 "type": "EvanVCSchema"
+    ///             },
+    ///             "credentialStatus": {
+    ///                 "id": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA#4",
+    ///                 "type": "RevocationList2020Status",
+    ///                 "revocationListIndex": "4",
+    ///                 "revocationListCredential": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA"
+    ///             },
+    ///             "credentialSubject": {
+    ///                 "id": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
+    ///                 "data": {
+    ///                     "bio": "biography"
+    ///                 }
+    ///             }
+    ///         }"###;
+    ///         async fn example() -> Result<()> {
+    ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
+    ///
+    ///             let presentation_result = vade_evan
+    ///               .helper_create_self_issued_presentation(
+    ///                  UNSIGNED_CREDENTIAL
+    ///                )
+    ///                .await;
+    ///
+    ///
+    ///             Ok(())
+    ///         }
+    ///     } else {
+    ///         // currently no example for target-c-sdk and c-lib/target-java-lib
+    ///     }
+    /// }
+    #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+    pub async fn helper_create_self_issued_presentation(
+        &mut self,
+        unsigned_credential_str: &str,
+    ) -> Result<String, VadeEvanError> {
+        use crate::helpers::Presentation;
+
+        let mut presentation_helper = Presentation::new(self)?;
+        presentation_helper
+            .create_self_issued_presentation(unsigned_credential_str)
+            .await
+            .map_err(|err| err.into())
+    }
+
     /// Verifies a presentation.
     /// The function checks if the presentation is valid against the provided proof request.
     ///

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -692,6 +692,25 @@ pub extern "C" fn execute_vade(
             }
         }),
         #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+        "helper_create_self_issued_presentation" => runtime.block_on({
+            async {
+                let mut vade_evan = get_vade_evan(
+                    Some(&str_config),
+                    #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
+                    ptr_request_list,
+                    #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
+                    request_function_callback,
+                )
+                .map_err(stringify_generic_error)?;
+                vade_evan
+                    .helper_create_self_issued_presentation(
+                        arguments_vec.get(0).unwrap_or_else(|| &no_args),
+                    )
+                    .await
+                    .map_err(stringify_vade_evan_error)
+            }
+        }),
+        #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
         "helper_verify_presentation" => runtime.block_on({
             async {
                 let mut vade_evan = get_vade_evan(

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -779,7 +779,7 @@ mod tests {
             .await?;
         let did_create_result: DidCreateResponse = serde_json::from_str(&did_create_result)?;
         let mut credential: BbsCredential = serde_json::from_str(CREDENTIAL_ACTIVE)?;
-        let mut credential_status = &mut credential.credential_status.ok_or_else(|| {
+        let mut credential_status = credential.credential_status.ok_or_else(|| {
             CredentialError::InvalidCredentialStatus(
                 "Error in parsing credential_status".to_string(),
             )
@@ -807,7 +807,7 @@ mod tests {
         assert!(did_update_result.is_ok());
 
         // check is credential is not revoked
-        match is_revoked(credential_status, &revocation_list)? {
+        match is_revoked(&credential_status, &revocation_list)? {
             false => assert!(true, "credential is active and not revoked as expected"),
             true => assert!(
                 false,
@@ -842,7 +842,7 @@ mod tests {
         revocation_list = did_result_value.did_document;
 
         // verify credential
-        match is_revoked(credential_status, &revocation_list)? {
+        match is_revoked(&credential_status, &revocation_list)? {
             false => assert!(false, "credential should have been detected as revoked"),
             true => assert!(true, "credential revoked as expected"),
         };
@@ -900,7 +900,8 @@ mod tests {
                 assert!(true, "credential should have been successfully self issued");
                 let unsigned_credential: UnsignedBbsCredential =
                     serde_json::from_str(&issued_credential)?;
-                let credential_subject = serde_json::to_string(&unsigned_credential.credential_subject)?;
+                let credential_subject =
+                    serde_json::to_string(&unsigned_credential.credential_subject)?;
                 assert_eq!(credential_subject_str, credential_subject.as_str());
                 assert_eq!(unsigned_credential.issuer, subject_id);
             }

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -740,7 +740,7 @@ mod tests_proof_request {
         let self_presentation_result_str = self_presentation_result?;
         assert!(
             !self_presentation_result_str.contains("proof"),
-            "Self Issued Presentation cannot contian proof"
+            "Self Issued Presentation can not contain proof"
         );
         Ok(())
     }

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -377,12 +377,12 @@ impl<'a> Presentation<'a> {
         unsigned_credential_str: &str,
     ) -> Result<String, PresentationError> {
         // Check if shared credential is signed instead of unsigned
-        match serde_json::from_str::<BbsCredential>(
-            unsigned_credential_str,
-        ){
-            Ok(_) => return Err(PresentationError::SelfIssuedCredentialWithProof()),
-            Err(_) => {},
-        };
+        let parsed = serde_json::from_str::<Value>(unsigned_credential_str).map_err(|err| {
+            PresentationError::JsonSerialization("unsigned credential".to_owned(), err.to_string())
+        })?;
+        if parsed.get("proof").is_some() {
+            return Err(PresentationError::SelfIssuedCredentialWithProof());
+        }
 
         let unsigned_credential: UnsignedBbsCredential = serde_json::from_str(
             unsigned_credential_str,

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -376,9 +376,14 @@ impl<'a> Presentation<'a> {
         &mut self,
         unsigned_credential_str: &str,
     ) -> Result<String, PresentationError> {
-        if unsigned_credential_str.contains("proof") {
-            return Err(PresentationError::SelfIssuedCredentialWithProof());
-        }
+        // Check if shared credential is signed instead of unsigned
+        match serde_json::from_str::<BbsCredential>(
+            unsigned_credential_str,
+        ){
+            Ok(_) => return Err(PresentationError::SelfIssuedCredentialWithProof()),
+            Err(_) => {},
+        };
+
         let unsigned_credential: UnsignedBbsCredential = serde_json::from_str(
             unsigned_credential_str,
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,6 +288,16 @@ async fn main() -> Result<()> {
                     )
                     .await?
             }
+            #[cfg(all(feature = "vc-zkp-bbs"))]
+            ("create_self_issued_presentation", Some(sub_m)) => {
+                get_vade_evan(sub_m)?
+                    .helper_create_self_issued_presentation(get_argument_value(
+                        sub_m,
+                        "unsigned_credential",
+                        None,
+                    ))
+                    .await?
+            }
             #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
             ("verify_presentation", Some(sub_m)) => {
                 get_vade_evan(sub_m)?
@@ -445,6 +455,15 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .arg(get_clap_argument("private_key")?)
                     .arg(get_clap_argument("subject_did")?)
                     .arg(get_clap_argument("revealed_attributes")?)
+            );
+        } else {}
+    }
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "vc-zkp-bbs"))] {
+            subcommand = subcommand.subcommand(
+                SubCommand::with_name("create_self_issued_presentation")
+                    .about("Creates a self issued presentation.")
+                    .arg(get_clap_argument("unsigned_credential")?)
             );
         } else {}
     }
@@ -948,6 +967,12 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
             .value_name("credential")
             .required(true)
             .help("credential to verity")
+            .takes_value(true),
+        "unsigned_credential" => Arg::with_name("unsigned_credential")
+            .long("unsigned_credential")
+            .value_name("unsigned_credential")
+            .required(true)
+            .help("Credential without proof")
             .takes_value(true),
         "master_secret" => Arg::with_name("master_secret")
             .long("master_secret")

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -167,6 +167,11 @@ struct HelperCreatePresentationPayload {
     pub prover_did: String,
     pub revealed_attributes: Option<String>,
 }
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HelperCreateSelftIssuedPresentationPayload {
+    unsigned_credential: String,
+}
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -368,6 +373,20 @@ cfg_if::cfg_if! {
                     &credential,
                     &update_key_jwk,
                     &private_key,
+                ).await
+                .map_err(jsify_vade_evan_error)?)
+        }
+
+
+        #[cfg(all(feature = "vc-zkp-bbs"))]
+        #[wasm_bindgen]
+        pub async fn helper_create_self_issued_presentation(
+            unsigned_credential: String,
+        ) -> Result<String, JsValue> {
+            let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
+            Ok(vade_evan
+                .helper_create_self_issued_presentation(
+                    &unsigned_credential
                 ).await
                 .map_err(jsify_vade_evan_error)?)
         }
@@ -764,6 +783,16 @@ pub async fn execute_vade(
                         payload.revealed_attributes,
                     )
                     .await
+                }
+                Err(error) => Err(get_parsing_error_message(&error, &payload)),
+            }
+        }
+        #[cfg(all(feature = "vc-zkp-bbs"))]
+        "helper_create_self_issued_presentation" => {
+            let payload_result = parse::<HelperCreateSelftIssuedPresentationPayload>(&payload);
+            match payload_result {
+                Ok(payload) => {
+                    helper_create_self_issued_presentation(payload.unsigned_credential).await
                 }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }


### PR DESCRIPTION
## Description

This MR adds support for self issued presentation i.e Presentations without proof which contain unsigned or self issued credentials.

## Details

- add helper function `helper_create_selft_issued_presentations`
- add tests
- update bindings
