### PR TITLE
Add proof proposals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,7 +4838,7 @@ dependencies = [
 [[package]]
 name = "vade-didcomm"
 version = "0.3.0"
-source = "git+https://github.com/evannetwork/vade-didcomm.git?branch=develop#edd2e0d1c3d767b91f186aee762062860b04d741"
+source = "git+https://github.com/evannetwork/vade-didcomm.git?branch=feature/update-presentation-proposal-data-format#24fa2a09c3837e5664f35d3c1839106ab8a80a1e"
 dependencies = [
  "async-trait",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4838,7 +4838,7 @@ dependencies = [
 [[package]]
 name = "vade-didcomm"
 version = "0.3.0"
-source = "git+https://github.com/evannetwork/vade-didcomm.git?branch=feature/update-presentation-proposal-data-format#24fa2a09c3837e5664f35d3c1839106ab8a80a1e"
+source = "git+https://github.com/evannetwork/vade-didcomm.git?branch=develop#a81044280dda775afea8846b00db99824c7daf79"
 dependencies = [
  "async-trait",
  "bs58",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.4.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/add-proof-proposals#e74425e3025b3ffcbc95fa8b0b34d86f6df04d4f"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=develop#2c977854b0ce03af63a98ce62aa9997b68b34604"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.4.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/add-proof-proposals#8f64cc6837718bd5867e63bb916bede469da59d6"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/add-proof-proposals#e74425e3025b3ffcbc95fa8b0b34d86f6df04d4f"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4825,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "vade"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28c510deb9534df9da15a2dce4602d1601a5ec9cf231293adffc0b39bfe877dc"
+checksum = "03e358313f2c726a5d6d7c8253a5f708f0d2dcca7c3606a7e4e2a5e94a9fd808"
 dependencies = [
  "async-trait",
  "env_logger 0.7.1",
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.4.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=develop#12b3b175dd9e22bc9564cec7b88e4cf50b19c215"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/add-proof-proposals#8f64cc6837718bd5867e63bb916bede469da59d6"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ required-features = ["target-cli"]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
 [features]
-default = ["did-sidetree", "did-substrate", "didcomm", "jwt-vc", "vc-zkp-bbs", "cli"]
+default = ["did-sidetree", "did-substrate", "didcomm", "jwt-vc", "vc-zkp-bbs"]
 
 did-sidetree = ["base64", "did-read", "did-write", "vade-sidetree", "uuid"]
 
@@ -62,7 +62,7 @@ target-c-sdk = ["c-lib", "vade-sidetree/sdk", "didcomm", "did-sidetree", "did-su
 target-c-lib = ["c-lib", "default"]
 
 # build for command line usage
-target-cli = ["default"]
+target-cli = ["cli"]
 
 # build for consuming vade-evan from Java
 target-java-lib = ["c-lib", "default"]
@@ -78,7 +78,7 @@ jni = "0.19.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0.53", features = ["preserve_order", "raw_value"] }
 thiserror = "1.0.38"
-vade = "0.1.0"
+vade = "0.1.1"
 chrono = "0.4.23"
 
 ###################################################################### feature specific dependencies
@@ -147,7 +147,8 @@ optional = true
 
 [dependencies.vade-evan-bbs]
 git = "https://github.com/evannetwork/vade-evan-bbs.git"
-branch = "develop"
+# branch = "develop"
+branch = "feature/add-proof-proposals"
 optional = true
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ required-features = ["target-cli"]
 wasm-opt = ["-Oz", "--enable-mutable-globals"]
 
 [features]
-default = ["did-sidetree", "did-substrate", "didcomm", "jwt-vc", "vc-zkp-bbs"]
+default = ["did-sidetree", "did-substrate", "didcomm", "jwt-vc", "vc-zkp-bbs", "target-cli"]
 
 did-sidetree = ["base64", "did-read", "did-write", "vade-sidetree", "uuid"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,8 @@ optional = true
 # didcomm
 [dependencies.vade-didcomm]
 git = "https://github.com/evannetwork/vade-didcomm.git"
-branch = "develop"
+# branch = "develop"
+branch = "feature/update-presentation-proposal-data-format"
 optional = true
 
 # jwt-vc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,8 +103,7 @@ optional = true
 # didcomm
 [dependencies.vade-didcomm]
 git = "https://github.com/evannetwork/vade-didcomm.git"
-# branch = "develop"
-branch = "feature/update-presentation-proposal-data-format"
+branch = "develop"
 optional = true
 
 # jwt-vc
@@ -148,8 +147,7 @@ optional = true
 
 [dependencies.vade-evan-bbs]
 git = "https://github.com/evannetwork/vade-evan-bbs.git"
-# branch = "develop"
-branch = "feature/add-proof-proposals"
+branch = "develop"
 optional = true
 default-features = false
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- add support for `vc_zkp_propose_proof` function in `vade-evan-bbs` plugin
+
 ### Fixes
 
 ### Deprecation

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -1305,6 +1305,46 @@ impl VadeEvan {
         )
     }
 
+    /// Proposes a zero-knowledge proof for one or more credentials issued under one or more specific schemas.
+    ///
+    /// # Arguments
+    ///
+    /// * `method` - method to propose a proof for (e.g. "did:example")
+    /// * `options` - JSON string with additional information supporting the proposal (e.g. authentication data)
+    /// * `payload` - JSON string with information for the proposal (e.g. actual data to write)
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// cfg_if::cfg_if! {
+    ///     if #[cfg(not(all(feature = "c-lib", feature = "target-c-sdk")))] {
+    ///         use anyhow::Result;
+    ///         use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
+    ///
+    ///         async fn example() -> Result<()> {
+    ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
+    ///             let result = vade_evan.vc_zkp_propose_proof("did:example", "", "").await?;
+    ///             println!("created proof proposal: {}", result);
+    ///             Ok(())
+    ///         }
+    ///     } else {
+    ///         // currently no example for target-c-sdk and c-lib/target-java-lib
+    ///     }
+    /// }
+    /// ```
+    pub async fn vc_zkp_propose_proof(
+        &mut self,
+        method: &str,
+        options: &str,
+        payload: &str,
+    ) -> Result<String, VadeEvanError> {
+        get_first_result(
+            self.vade
+                .vc_zkp_propose_proof(method, options, payload)
+                .await?,
+        )
+    }
+
     /// Presents a proof for a zero-knowledge proof credential. A proof presentation is the response to a
     /// proof request.
     ///

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -497,7 +497,7 @@ impl VadeEvan {
     }
 
     /// Proposes to share a proof for a credential.
-    /// The proof proposal consists of the fields the verifier wants to be revealed per schema.
+    /// The proof proposal consists of the fields the prover wants to reveal per schema.
     ///
     /// # Arguments
     ///

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -481,6 +481,20 @@ pub extern "C" fn execute_vade(
             )
         }),
         #[cfg(any(feature = "vc-zkp-bbs"))]
+        "vc_zkp_propose_proof" => runtime.block_on({
+            execute_vade_function!(
+                vc_zkp_propose_proof,
+                arguments_vec.get(0).unwrap_or_else(|| &no_args),
+                &str_options,
+                arguments_vec.get(1).unwrap_or_else(|| &no_args),
+                str_config,
+                #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
+                ptr_request_list,
+                #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
+                request_function_callback
+            )
+        }),
+        #[cfg(any(feature = "vc-zkp-bbs"))]
         "vc_zkp_request_proof" => runtime.block_on({
             execute_vade_function!(
                 vc_zkp_request_proof,

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -662,6 +662,27 @@ pub extern "C" fn execute_vade(
             }
         }),
         #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+        "helper_create_proof_proposal" => runtime.block_on({
+            async {
+                let mut vade_evan = get_vade_evan(
+                    Some(&str_config),
+                    #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
+                    ptr_request_list,
+                    #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
+                    request_function_callback,
+                )
+                .map_err(stringify_generic_error)?;
+
+                vade_evan
+                    .helper_create_proof_proposal(
+                        arguments_vec.get(0).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(1).map(|v| v.as_str()),
+                    )
+                    .await
+                    .map_err(stringify_vade_evan_error)
+            }
+        }),
+        #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
         "helper_create_proof_request" => runtime.block_on({
             async {
                 let mut vade_evan = get_vade_evan(
@@ -672,13 +693,23 @@ pub extern "C" fn execute_vade(
                     request_function_callback,
                 )
                 .map_err(stringify_generic_error)?;
-                vade_evan
-                    .helper_create_proof_request(
-                        arguments_vec.get(0).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(1).map(|v| v.as_str()),
-                    )
-                    .await
-                    .map_err(stringify_vade_evan_error)
+
+                let first_arg = arguments_vec.get(0).unwrap_or_else(|| &no_args);
+                match first_arg.starts_with("did:") {
+                    // first arg starts with "did:", assume it's a schema
+                    true => vade_evan
+                        .helper_create_proof_request(
+                            first_arg,
+                            arguments_vec.get(1).map(|v| v.as_str()),
+                        )
+                        .await
+                        .map_err(stringify_vade_evan_error),
+                    // else assume it's a proposal
+                    false => vade_evan
+                        .helper_create_proof_request_from_proposal(first_arg)
+                        .await
+                        .map_err(stringify_vade_evan_error),
+                }
             }
         }),
         #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -879,7 +879,7 @@ mod tests {
             .await?;
         let did_create_result: DidCreateResponse = serde_json::from_str(&did_create_result)?;
         let mut credential: BbsCredential = serde_json::from_str(CREDENTIAL_ACTIVE)?;
-        let mut credential_status = &mut credential.credential_status.ok_or_else(|| {
+        let credential_status = &mut credential.credential_status.ok_or_else(|| {
             CredentialError::InvalidCredentialStatus(
                 "Error in parsing credential_status".to_string(),
             )

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -11,6 +11,7 @@ use vade_evan_bbs::{
     CredentialSchema,
     PresentProofPayload,
     ProofPresentation,
+    ProposeProofPayload,
     RequestProofPayload,
     RequestProofPayloadFromScratch,
     VerifyProofPayload,
@@ -86,6 +87,67 @@ impl<'a> Presentation<'a> {
         Ok(Self { vade_evan })
     }
 
+    /// Proposes to issue a proof for a credential.
+    /// The proof proposal consists of the fields the verifier wants to be revealed per schema.
+    ///
+    /// # Arguments
+    ///
+    /// * `schema_did` - DID of schema to request proof for
+    /// * `revealed_attributes` - list of names of revealed attributes in specified schema, reveals all if omitted
+    ///
+    /// # Returns
+    /// * `Option<String>` - A `ProofProposal` as JSON
+    pub async fn create_proof_proposal(
+        &mut self,
+        schema_did: &str,
+        revealed_attributes: Option<&str>,
+    ) -> Result<String, PresentationError> {
+        let revealed_attributes = check_for_optional_empty_params(revealed_attributes);
+        let revealed_attributes_parsed: Option<Vec<String>> = revealed_attributes
+            .map(|ras| {
+                serde_json::from_str(ras).map_err(PresentationError::to_deserialization_error(
+                    "revealed attributes",
+                    ras,
+                ))
+            })
+            .transpose()?;
+        let proof_proposal_payload = ProposeProofPayload {
+            verifier_did: None,
+            schemas: vec![schema_did.to_string()],
+            reveal_attributes: self
+                .get_reveal_attributes_indices_map(schema_did, revealed_attributes_parsed)
+                .await?,
+        };
+
+        let proof_proposal_json = serde_json::to_string(&proof_proposal_payload).map_err(
+            PresentationError::to_serialization_error("ProposeProofPayload"),
+        )?;
+
+        self.vade_evan
+            .vc_zkp_propose_proof(EVAN_METHOD, TYPE_OPTIONS, &proof_proposal_json)
+            .await
+            .map_err(|err| PresentationError::VadeEvanError(err.to_string()))
+    }
+
+    /// Requests a proof for a credential by providing a proposal.
+    /// The proof request consists of the fields the verifier wants to be revealed per schema.
+    ///
+    /// # Arguments
+    ///
+    /// * `proof_proposal` - proof proposal to use to generate a proof request from
+    ///
+    /// # Returns
+    /// * `Option<String>` - A `ProofRequest` as JSON
+    pub async fn create_proof_request_from_proposal(
+        &mut self,
+        proof_proposal: &str,
+    ) -> Result<String, PresentationError> {
+        self.vade_evan
+            .vc_zkp_request_proof(EVAN_METHOD, TYPE_OPTIONS, proof_proposal)
+            .await
+            .map_err(|err| PresentationError::VadeEvanError(err.to_string()))
+    }
+
     /// Requests a proof for a credential.
     /// The proof request consists of the fields the verifier wants to be revealed per schema.
     ///
@@ -155,7 +217,7 @@ impl<'a> Presentation<'a> {
 
         let credential = presentation.verifiable_credential.get(0).ok_or_else(|| {
             PresentationError::InvalidPresentationError(
-                "Credentail not found in presentation".to_owned(),
+                "Credential not found in presentation".to_owned(),
             )
         })?;
 
@@ -438,7 +500,12 @@ impl<'a> Presentation<'a> {
 mod tests_proof_request {
 
     use anyhow::Result;
-    use vade_evan_bbs::{BbsProofRequest, BbsProofVerification};
+    use vade_evan_bbs::{
+        BbsProofProposal,
+        BbsProofRequest,
+        BbsProofVerification,
+        BbsSubProofRequest,
+    };
 
     use crate::{VadeEvan, DEFAULT_SIGNER, DEFAULT_TARGET};
 
@@ -491,6 +558,41 @@ mod tests_proof_request {
            "signature":"sZTYWUrmYaVDUGs1L2UM/7f7UlVLSQS2vPQQG1YWU3TQRlcviNXFDx054zztzG8rWc1lw5e+SJNo4c1x+rpOFiXBjjK6IukN3a0zG5c/ayFbIQ6OVjxV7noWX8aTdNXNO5eyVV2Upd1YB4WGAuUO0w=="
         }
     }"###;
+
+    #[tokio::test]
+    async fn helper_can_create_proof_request_from_proposal() -> Result<()> {
+        let mut vade_evan = VadeEvan::new(crate::VadeEvanConfig {
+            target: DEFAULT_TARGET,
+            signer: DEFAULT_SIGNER,
+        })?;
+        let mut presentation = Presentation::new(&mut vade_evan)?;
+
+        let proposal = BbsProofProposal {
+            verifier: Some("verifier".to_string()),
+            created_at: "created_at".to_string(),
+            nonce: "nonce".to_string(),
+            r#type: "BBS".to_string(),
+            sub_proof_requests: vec![BbsSubProofRequest {
+                schema: SCHEMA_DID.to_string(),
+                revealed_attributes: vec![13, 15],
+            }],
+        };
+        let proposal_str = serde_json::to_string(&proposal)?;
+
+        let result = presentation
+            .create_proof_request_from_proposal(&proposal_str)
+            .await;
+
+        assert!(result.is_ok());
+        let mut parsed: BbsProofRequest = serde_json::from_str(&result?)?;
+        assert_eq!(parsed.r#type, "BBS");
+        assert_eq!(parsed.sub_proof_requests[0].schema, SCHEMA_DID);
+        parsed.sub_proof_requests[0].revealed_attributes.sort();
+        assert_eq!(parsed.sub_proof_requests[0].revealed_attributes, [13, 15],);
+
+        Ok(())
+    }
+
     #[tokio::test]
     async fn helper_can_create_proof_request() -> Result<()> {
         let mut vade_evan = VadeEvan::new(crate::VadeEvanConfig {

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -12,6 +12,7 @@ use vade_evan_bbs::{
     PresentProofPayload,
     ProofPresentation,
     RequestProofPayload,
+    RequestProofPayloadFromScratch,
     VerifyProofPayload,
 };
 
@@ -109,13 +110,14 @@ impl<'a> Presentation<'a> {
                 ))
             })
             .transpose()?;
-        let proof_request_payload = RequestProofPayload {
-            verifier_did: None,
-            schemas: vec![schema_did.to_string()],
-            reveal_attributes: self
-                .get_reveal_attributes_indices_map(schema_did, revealed_attributes_parsed)
-                .await?,
-        };
+        let proof_request_payload =
+            RequestProofPayload::FromScratch(RequestProofPayloadFromScratch {
+                verifier_did: None,
+                schemas: vec![schema_did.to_string()],
+                reveal_attributes: self
+                    .get_reveal_attributes_indices_map(schema_did, revealed_attributes_parsed)
+                    .await?,
+            });
 
         let proof_request_json = serde_json::to_string(&proof_request_payload).map_err(
             PresentationError::to_serialization_error("RequestProofPayload"),

--- a/src/helpers/shared.rs
+++ b/src/helpers/shared.rs
@@ -64,6 +64,7 @@ pub fn create_draft_credential_from_schema(
         },
         issuance_date: "2021-01-01T00:00:00.000Z".to_string(),
         credential_subject: CredentialSubject {
+            id: None,
             data: schema // fill ALL subject data fields with empty string (mandatory and optional ones)
                 .properties
                 .clone()

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,10 @@ async fn main() -> Result<()> {
                 wrap_vade3!(vc_zkp_request_credential, sub_m)
             }
             #[cfg(feature = "vc-zkp-bbs")]
+            ("propose_proof", Some(sub_m)) => {
+                wrap_vade3!(vc_zkp_propose_proof, sub_m)
+            }
+            #[cfg(feature = "vc-zkp-bbs")]
             ("request_proof", Some(sub_m)) => {
                 wrap_vade3!(vc_zkp_request_proof, sub_m)
             }
@@ -684,6 +688,20 @@ fn add_subcommand_vc_zkp<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("request_credential")
                     .about("Requests a credential. This message is the response to a credential offering and is sent by the potential credential holder. It incorporates the target schema offered by the issuer, and the encoded values the holder wants to get signed. The credential is not stored on-chain and needs to be kept private.")
+                    .arg(get_clap_argument("method")?)
+                    .arg(get_clap_argument("options")?)
+                    .arg(get_clap_argument("payload")?)
+                    .arg(get_clap_argument("target")?)
+                    .arg(get_clap_argument("signer")?),
+            );
+        } else {}
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "vc-zkp-bbs")] {
+            subcommand = subcommand.subcommand(
+                SubCommand::with_name("propose_proof")
+                    .about("Proposes a zero-knowledge proof for one or more credentials issued under one or more specific schemas and is sent by a verifier to a prover. The proof proposal consists of the fields the verifier wants to be revealed per schema and can be used as input for a proof request.")
                     .arg(get_clap_argument("method")?)
                     .arg(get_clap_argument("options")?)
                     .arg(get_clap_argument("payload")?)

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -153,11 +153,17 @@ struct HelperCreateSelfIssuedCredentialPayload {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct HelperCreateProofRequestFomScratchPayload {
+struct HelperCreateProofProposalPayload {
     pub schema_did: String,
     pub revealed_attributes: Option<String>,
 }
 
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HelperCreateProofRequestFomScratchPayload {
+    pub schema_did: String,
+    pub revealed_attributes: Option<String>,
+}
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -783,7 +789,7 @@ pub async fn execute_vade(
         }
         #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
         "helper_create_proof_proposal" => {
-            let payload_result = parse::<HelperCreateProofRequestPayload>(&payload);
+            let payload_result = parse::<HelperCreateProofProposalPayload>(&payload);
             match payload_result {
                 Ok(payload) =>
                     helper_create_proof_proposal(payload.schema_did, payload.revealed_attributes).await,

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -255,6 +255,8 @@ cfg_if::cfg_if! {
         #[cfg(feature = "vc-zkp-bbs")]
         create_function!(vc_zkp_request_credential, did_or_method, options, payload, config);
         #[cfg(feature = "vc-zkp-bbs")]
+        create_function!(vc_zkp_propose_proof, did_or_method, options, payload, config);
+        #[cfg(feature = "vc-zkp-bbs")]
         create_function!(vc_zkp_request_proof, did_or_method, options, payload, config);
         #[cfg(feature = "vc-zkp-bbs")]
         create_function!(vc_zkp_revoke_credential, did_or_method, options, payload, config);
@@ -615,6 +617,10 @@ pub async fn execute_vade(
         #[cfg(feature = "vc-zkp-bbs")]
         "vc_zkp_request_credential" => {
             vc_zkp_request_credential(did_or_method, options, payload, config).await
+        }
+        #[cfg(feature = "vc-zkp-bbs")]
+        "vc_zkp_propose_proof" => {
+            vc_zkp_propose_proof(did_or_method, options, payload, config).await
         }
         #[cfg(feature = "vc-zkp-bbs")]
         "vc_zkp_request_proof" => {


### PR DESCRIPTION
## Description

Adds support for proof proposals.

## Details

- adds support to create proof proposals
- adds support to pass proof proposals to credential requests (as alternative to schema, attributes, and verifier)