### PR TITLE
Enable didcomm feature for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ target-cli = ["cli"]
 target-java-lib = ["c-lib", "default"]
 
 # build for usage in wasm
-target-wasm = ["vade-didcomm/wasm", "vade-evan-bbs/wasm", "did-sidetree", "did-substrate", "jwt-vc", "vc-zkp-bbs"]
+target-wasm = ["vade-didcomm/wasm", "didcomm", "vade-evan-bbs/wasm", "did-sidetree", "did-substrate", "jwt-vc", "vc-zkp-bbs"]
 
 ############################################################################### generic dependencies
 [dependencies]


### PR DESCRIPTION
Because in the wasm build, there was no didcomm feature enabled, it was skipped for the wasm binary.