### PR TITLE
update vade-evan-bbs dependency and make proof optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.4.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/remove-additional-proof-gen-from-presentations#16cc78106dac628ddeadab269dff477b3106a2ed"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=experimental/develop-next#5670c833e971bb56251d8be092024d08e83dfc4a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4911,7 +4911,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.4.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=experimental/develop-next#78e1ab90424b6931c8c3590fb9ed07d916847789"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/remove-additional-proof-gen-from-presentations#16cc78106dac628ddeadab269dff477b3106a2ed"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ optional = true
 
 [dependencies.vade-evan-bbs]
 git = "https://github.com/evannetwork/vade-evan-bbs.git"
-branch = "feature/remove-additional-proof-gen-from-presentations"
+branch = "experimental/develop-next"
 optional = true
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ optional = true
 
 [dependencies.vade-evan-bbs]
 git = "https://github.com/evannetwork/vade-evan-bbs.git"
-branch = "experimental/develop-next"
+branch = "feature/remove-additional-proof-gen-from-presentations"
 optional = true
 default-features = false
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -36,6 +36,7 @@
 - adjust `helper_create_self_issued_credential` to create credentials without proof.
 - add helper function `helper_create_self_issued_presentation` function
 - update `vade-evan-bbs` dependency for revocation fix
+- update `vade-evan-bbs` dependency optional proof in `ProofPresentation`
 
 ### Fixes
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -896,8 +896,8 @@ impl VadeEvan {
     ///                   &proof_request_str,
     ///                   CREDENTIAL,
     ///                   MASTER_SECRET,
-    ///                   SIGNER_PRIVATE_KEY,
-    ///                   PROVER_DID,
+    ///                   Some(SIGNER_PRIVATE_KEY),
+    ///                   Some(PROVER_DID),
     ///                   None,
     ///                )
     ///                .await?;

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -718,8 +718,8 @@ impl VadeEvan {
     ///                   &proof_request_str,
     ///                   CREDENTIAL,
     ///                   MASTER_SECRET,
-    ///                   SIGNER_PRIVATE_KEY,
-    ///                   PROVER_DID,
+    ///                   Some(SIGNER_PRIVATE_KEY),
+    ///                   Some(PROVER_DID),
     ///                   None,
     ///                )
     ///                .await;
@@ -736,8 +736,8 @@ impl VadeEvan {
         proof_request_str: &str,
         credential_str: &str,
         master_secret: &str,
-        signing_key: &str,
-        prover_did: &str,
+        signing_key: Option<&str>,
+        prover_did: Option<&str>,
         revealed_attributes: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         let mut presentation_helper = Presentation::new(self)?;

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -723,8 +723,8 @@ pub extern "C" fn execute_vade(
                         arguments_vec.get(0).unwrap_or_else(|| &no_args),
                         arguments_vec.get(1).unwrap_or_else(|| &no_args),
                         arguments_vec.get(2).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(3).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(4).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(3).map(|v| v.as_str()),
+                        arguments_vec.get(4).map(|v| v.as_str()),
                         arguments_vec.get(5).map(|v| v.as_str()),
                     )
                     .await

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -329,8 +329,8 @@ impl<'a> Presentation<'a> {
         proof_request_str: &str,
         credential_str: &str,
         master_secret: &str,
-        signing_key: &str,
-        prover_did: &str,
+        signing_key: Option<&str>,
+        prover_did: Option<&str>,
         revealed_attributes: Option<&str>,
     ) -> Result<String, PresentationError> {
         let revealed_attributes = check_for_optional_empty_params(revealed_attributes);
@@ -413,9 +413,12 @@ impl<'a> Presentation<'a> {
             revealed_properties_schema_map,
             public_key_schema_map,
             master_secret: master_secret.to_owned(),
-            prover_did: prover_did.to_owned(),
-            prover_public_key_did: format!("{}#key-1", prover_did.to_owned()),
-            prover_proving_key: signing_key.to_owned(),
+            prover_did: prover_did.map(|x| x.to_owned()),
+            prover_public_key_did: match prover_did {
+                Some(did) => Some(format!("{}#key-1", did.to_owned())),
+                _ => None,
+            },
+            prover_proving_key: signing_key.map(|x| x.to_owned()),
         };
 
         let payload = serde_json::to_string(&present_proof_payload).map_err(|err| {
@@ -824,8 +827,8 @@ mod tests_proof_request {
                 proof_request_str,
                 CREDENTIAL,
                 MASTER_SECRET,
-                SIGNER_PRIVATE_KEY,
-                SUBJECT_DID,
+                Some(SIGNER_PRIVATE_KEY),
+                Some(SUBJECT_DID),
                 None,
             )
             .await;
@@ -899,8 +902,8 @@ mod tests_proof_request {
                 proof_request_str,
                 CREDENTIAL,
                 MASTER_SECRET,
-                SIGNER_PRIVATE_KEY,
-                SUBJECT_DID,
+                Some(SIGNER_PRIVATE_KEY),
+                Some(SUBJECT_DID),
                 None,
             )
             .await;
@@ -935,8 +938,8 @@ mod tests_proof_request {
                 &proof_request_result?,
                 CREDENTIAL,
                 MASTER_SECRET,
-                SIGNER_PRIVATE_KEY,
-                SUBJECT_DID,
+                Some(SIGNER_PRIVATE_KEY),
+                Some(SUBJECT_DID),
                 None,
             )
             .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,8 +299,8 @@ async fn main() -> Result<()> {
                         get_argument_value(sub_m, "proof_request", None),
                         get_argument_value(sub_m, "credential", None),
                         get_argument_value(sub_m, "master_secret", None),
-                        get_argument_value(sub_m, "private_key", None),
-                        get_argument_value(sub_m, "subject_did", None),
+                        get_optional_argument_value(sub_m, "private_key"),
+                        get_optional_argument_value(sub_m, "subject_did"),
                         get_optional_argument_value(sub_m, "revealed_attributes"),
                     )
                     .await?

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -173,8 +173,8 @@ struct HelperCreatePresentationPayload {
     pub proof_request_str: String,
     pub credential_str: String,
     pub master_secret: String,
-    pub signing_key: String,
-    pub prover_did: String,
+    pub signing_key: Option<String>,
+    pub prover_did: Option<String>,
     pub revealed_attributes: Option<String>,
 }
 #[derive(Serialize, Deserialize)]
@@ -486,8 +486,8 @@ cfg_if::cfg_if! {
             proof_request_str:String,
             credential_str: String,
             master_secret: String,
-            signing_key: String,
-            prover_did: String,
+            signing_key: Option<String>,
+            prover_did: Option<String>,
             revealed_attributes: Option<String>,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
@@ -496,8 +496,8 @@ cfg_if::cfg_if! {
                     &proof_request_str,
                     &credential_str,
                     &master_secret,
-                    &signing_key,
-                    &prover_did,
+                    signing_key.as_deref(),
+                    prover_did.as_deref(),
                     revealed_attributes.as_deref(),
                 ).await
                 .map_err(jsify_vade_evan_error)?)


### PR DESCRIPTION
## Description

This mr updates vade-evan-bbs dependency and makes changes to mark proof of `ProofPresentation`  as optional 

## Details

- Update vade-evan-bbs dependency
- Adjust Presentation helper `create_presentaiton` function
- Update binding for c, wasm , cli 
