### PR TITLE
Fix proof request input parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4868,7 +4868,7 @@ dependencies = [
 
 [[package]]
 name = "vade-evan"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vade-evan"
-version = "0.6.0-rc.3"
+version = "0.6.0-rc.5"
 authors = ["evan GmbH"]
 edition = "2018"
 license-file = "LICENSE.txt"

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -166,7 +166,7 @@ struct HelperCreateProofRequestFomScratchPayload {
 }
 
 #[derive(Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", untagged)]
 enum HelperCreateProofRequestPayload {
     FromScratch(HelperCreateProofRequestFomScratchPayload),
     FromProposal(BbsProofProposal),


### PR DESCRIPTION
Fixes parsing for proof request.

## Details

- wrong implementation would require external tagging with "fromScratch"/"fromProposal"
- now properly supports untagged union-like inputs as intended