### PR TITLE
Make proofs optional for request list credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,11 +4912,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.4.0"
-<<<<<<< HEAD
 source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=experimental/develop-next#7ec152939fd3d106b171a8ad58c26f35c8a5c776"
-=======
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=experimental/develop-next#5670c833e971bb56251d8be092024d08e83dfc4a"
->>>>>>> experimental/develop-next
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4691,7 +4691,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]
@@ -4912,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.4.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=develop#2c977854b0ce03af63a98ce62aa9997b68b34604"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=develop#0000431e6c3ea3cd9de9ab2bee6e4be6bb32d4a9"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,14 +4,40 @@
 
 ### Features
 
-- add support for `vc_zkp_propose_proof` function in `vade-evan-bbs` plugin
-- add checks to ensure inputs that are supposed to be DIDs are really DIDs
+- add support to skip proof generation for revocation lists and when updating them (happens during revocation)
+  - updated functions:
+    - `vc_zkp_create_revocation_registry_definition`
+    - `vc_zkp_revoke_credential`
+  - these properties in payload are now optional:
+    - `issuer_public_key_did`
+    - `issuer_proving_key`
 
 ### Fixes
 
-- fix timestamp generation for `vade-didcomm` in `wasm` build
-
 ### Deprecation
+
+- helper calls now have a different setup for `revoke_credential`
+  - CLI calls for `helper revoke_credential`
+    - drop mandatory argument `private_key`
+    - get two new optional arguments `issuer_public_key_did` and `issuer_proving_key`
+  - C calls have the arguments for `helper_revoke_credential` updated
+    - positional 3rd argument (`private_key`) is moved to position 4 (`issuer_proving_key`)
+    - new 3rd argument is now the verification method of the revocation list credential proof (`issuer_public_key_did`)
+    - arguments now have the following order:
+      - `credential: &str,`
+      - `update_key_jwk: &str,`
+      - `issuer_public_key_did: Option<&str>,`
+      - `issuer_proving_key: Option<&str>,`
+  - WASM calls now have the payload for `helper_revoke_credential` updated:
+    - drop mandatory property `private_key`
+    - get two new optional properties `issuer_public_key_did` and `issuer_proving_key`
+- with proofs for revocation lists now being optional, the following updates to the exported types have been made:
+  - `RevocationListCredential::proof` is now optional
+  - `UnproofedRevocationListCredential` has been removed as proof of aforementioned struct can be set to `None`
+- struct `AuthenticationOptions` and its usage has been removed as `identity` and `private_key` (in options) were not used anymore
+- TypeScript typings updates
+  - `UnproofedRevocationListCredential` has been marked as deprecated and will be removed in the future
+  - `AuthenticationOptions` has been marked as deprecated and will be removed in the future
 
 ## Release candidates
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -853,11 +853,14 @@ impl VadeEvan {
 
     /// Revokes a given credential with the help of vade and updates revocation list credential
     ///
+    /// Proof generation is omitted if `issuer_public_key_did` or `issuer_proving_key` is omitted.
+    ///
     /// # Arguments
     ///
     /// * `credential` - credential to be revoked as serialized JSON
     /// * `update_key_jwk` - update key in jwk format as serialized JSON
-    /// * `private_key` - private key for local signer to be used for signing
+    /// * `issuer_public_key_did` - private key used for assertion proof
+    /// * `issuer_proving_key` - public key used for assertion proof
     ///
     /// # Example
     ///
@@ -917,8 +920,12 @@ impl VadeEvan {
     ///
     ///             // revoke the credential issuer
     ///             vade_evan
-    ///                 .helper_revoke_credential(credential, update_key_jwk, "dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106")
-    ///                 .await?;
+    ///                 .helper_revoke_credential(
+    ///                     credential,
+    ///                     update_key_jwk,
+    ///                     Some("did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA#bbs-key-1"),
+    ///                     Some("dfcdcb6d5d09411ae9cbe1b0fd9751ba8803dd4b276d5bf9488ae4ede2669106"),
+    ///                 ).await?;
     ///
     ///             Ok(())
     ///         }
@@ -931,11 +938,17 @@ impl VadeEvan {
         &mut self,
         credential: &str,
         update_key_jwk: &str,
-        private_key: &str,
+        issuer_public_key_did: Option<&str>,
+        issuer_proving_key: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         let mut credential_helper = Credential::new(self)?;
         credential_helper
-            .revoke_credential(credential, update_key_jwk, private_key)
+            .revoke_credential(
+                credential,
+                update_key_jwk,
+                issuer_public_key_did,
+                issuer_proving_key,
+            )
             .await
             .map_err(|err| err.into())
     }

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -627,7 +627,8 @@ pub extern "C" fn execute_vade(
                     .helper_revoke_credential(
                         arguments_vec.get(0).unwrap_or_else(|| &no_args),
                         arguments_vec.get(1).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(2).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(2).map(|v| v.as_str()),
+                        arguments_vec.get(3).map(|v| v.as_str()),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)?;

--- a/src/helpers/presentation.rs
+++ b/src/helpers/presentation.rs
@@ -60,7 +60,7 @@ pub enum PresentationError {
     SelfIssuedCredentialWithProof(),
 }
 
-/// A
+/// Self issued presentation that does not contain a proof.
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct SelfIssuedPresentation {

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,7 +248,8 @@ async fn main() -> Result<()> {
                     .helper_revoke_credential(
                         get_argument_value(sub_m, "credential", None),
                         get_argument_value(sub_m, "update_key", None),
-                        get_argument_value(sub_m, "private_key", None),
+                        get_optional_argument_value(sub_m, "issuer_public_key_did"),
+                        get_optional_argument_value(sub_m, "issuer_proving_key"),
                     )
                     .await?
             }
@@ -1012,6 +1013,16 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
             .value_name("private_key")
             .required(true)
             .help("private key to be supplied for local signer")
+            .takes_value(true),
+        "issuer_public_key_did" => Arg::with_name("issuer_public_key_did")
+            .long("issuer_public_key_did")
+            .value_name("issuer_public_key_did")
+            .help("public key used for assertion proofs")
+            .takes_value(true),
+        "issuer_proving_key" => Arg::with_name("issuer_proving_key")
+            .long("issuer_proving_key")
+            .value_name("issuer_proving_key")
+            .help("private key used for assertion proofs")
             .takes_value(true),
         "credential_revocation_did" => Arg::with_name("credential_revocation_did")
             .long("credential_revocation_did")

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -441,20 +441,6 @@ cfg_if::cfg_if! {
                 .map_err(jsify_vade_evan_error)?)
         }
 
-        #[wasm_bindgen]
-        pub async fn helper_create_proof_proposal(
-            schema_did: String,
-            revealed_attributes: Option<String>,
-        ) -> Result<String, JsValue> {
-            let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
-            Ok(vade_evan
-                .helper_create_proof_proposal(
-                    &schema_did,
-                    revealed_attributes.as_deref(),
-                ).await
-                .map_err(jsify_vade_evan_error)?)
-        }
-
         #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
         #[wasm_bindgen]
         pub async fn helper_create_proof_proposal(

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -127,7 +127,8 @@ struct HelperCreateCredentialRequestPayload {
 struct HelperRevokeCredentialPayload {
     pub credential: String,
     pub update_key_jwk: String,
-    pub private_key: String,
+    pub issuer_public_key_did: Option<String>,
+    pub issuer_proving_key: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -377,14 +378,16 @@ cfg_if::cfg_if! {
         pub async fn helper_revoke_credential(
             credential: String,
             update_key_jwk: String,
-            private_key: String,
+            issuer_public_key_did: Option<String>,
+            issuer_proving_key: Option<String>,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
             Ok(vade_evan
                 .helper_revoke_credential(
                     &credential,
                     &update_key_jwk,
-                    &private_key,
+                    issuer_public_key_did.as_deref(),
+                    issuer_proving_key.as_deref(),
                 ).await
                 .map_err(jsify_vade_evan_error)?)
         }
@@ -749,7 +752,8 @@ pub async fn execute_vade(
                     helper_revoke_credential(
                         payload.credential,
                         payload.update_key_jwk,
-                        payload.private_key,
+                        payload.issuer_public_key_did,
+                        payload.issuer_proving_key,
                     )
                     .await
                 }

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -441,7 +441,6 @@ cfg_if::cfg_if! {
                 .map_err(jsify_vade_evan_error)?)
         }
 
-        #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
         #[wasm_bindgen]
         pub async fn helper_create_proof_proposal(
             schema_did: String,


### PR DESCRIPTION
Makes proofs optional for request list credentials.

## Details

### Features

- add support to skip proof generation for revocation lists and when updating them (happens during revocation)
  - updated functions:
    - `vc_zkp_create_revocation_registry_definition`
    - `vc_zkp_revoke_credential`
  - these properties in payload are now optional:
    - `issuer_public_key_did`
    - `issuer_proving_key`

### Deprecations

- helper calls now have a different setup for `revoke_credential`
  - CLI calls for `helper revoke_credential`
    - drop mandatory argument `private_key`
    - get two new optional arguments `issuer_public_key_did` and `issuer_proving_key`
  - C calls have the arguments for `helper_revoke_credential` updated
    - positional 3rd argument (`private_key`) is moved to position 4 (`issuer_proving_key`)
    - new 3rd argument is now the verification method of the revocation list credential proof (`issuer_public_key_did`)
    - arguments now have the following order:
      - `credential: &str,`
      - `update_key_jwk: &str,`
      - `issuer_public_key_did: Option<&str>,`
      - `issuer_proving_key: Option<&str>,`
  - WASM calls now have the payload for `helper_revoke_credential` updated:
    - drop mandatory property `private_key`
    - get two new optional properties `issuer_public_key_did` and `issuer_proving_key`
- with proofs for revocation lists now being optional, the following updates to the exported types have been made:
  - `RevocationListCredential::proof` is now optional
  - `UnproofedRevocationListCredential` has been removed as proof of aforementioned struct can be set to `None`
- struct `AuthenticationOptions` and its usage has been removed as `identity` and `private_key` (in options) were not used anymore
- TypeScript typings updates
  - `UnproofedRevocationListCredential` has been marked as deprecated and will be removed in the future
  - `AuthenticationOptions` has been marked as deprecated and will be removed in the future