### PR TITLE
Add helper convert to nquads

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -5,6 +5,7 @@
 ### Features
 
 - add support for `vc_zkp_propose_proof` function in `vade-evan-bbs` plugin
+- add `helper_convert_credential_to_nquads` helper function
 
 ### Fixes
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -496,6 +496,84 @@ impl VadeEvan {
             .map_err(|err| err.into())
     }
 
+    /// Converts a given credential to nquads Vector
+    ///
+    /// # Arguments
+    ///
+    /// * `credential` - credential to be converted to nquads
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// cfg_if::cfg_if! {
+    ///     if #[cfg(not(all(feature = "c-lib", feature = "target-c-sdk")))] {
+    ///         use anyhow::Result;
+    ///         use vade_evan::{VadeEvan, VadeEvanConfig, DEFAULT_TARGET, DEFAULT_SIGNER};
+    ///
+    ///         async fn example() -> Result<()> {
+    ///             let mut vade_evan = VadeEvan::new(VadeEvanConfig { target: DEFAULT_TARGET, signer: DEFAULT_SIGNER })?;
+    ///             let credential = r###"{
+    ///                 "id": "uuid:70b7ec4e-f035-493e-93d3-2cf5be4c7f88",
+    ///                 "type": [
+    ///                     "VerifiableCredential"
+    ///                 ],
+    ///                 "proof": {
+    ///                     "type": "BbsBlsSignature2020",
+    ///                     "created": "2023-02-01T14:08:17.000Z",
+    ///                     "signature": "kvSyi40dnZ5S3/mSxbSUQGKLpyMXDQNLCPtwDGM9GsnNNKF7MtaFHXIbvXaVXku0EY/n2uNMQ2bmK2P0KEmzgbjRHtzUOWVdfAnXnVRy8/UHHIyJR471X6benfZk8KG0qVqy+w67z9g628xRkFGA5Q==",
+    ///                     "proofPurpose": "assertionMethod",
+    ///                     "verificationMethod": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA#bbs-key-1",
+    ///                     "credentialMessageCount": 13,
+    ///                     "requiredRevealStatements": []
+    ///                 },
+    ///                 "issuer": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
+    ///                 "@context": [
+    ///                     "https://www.w3.org/2018/credentials/v1",
+    ///                     "https://schema.org/",
+    ///                     "https://w3id.org/vc-revocation-list-2020/v1"
+    ///                 ],
+    ///                 "issuanceDate": "2023-02-01T14:08:09.849Z",
+    ///                 "credentialSchema": {
+    ///                     "id": "did:evan:EiCimsy3uWJ7PivWK0QUYSCkImQnjrx6fGr6nK8XIg26Kg",
+    ///                     "type": "EvanVCSchema"
+    ///                 },
+    ///                 "credentialStatus": {
+    ///                     "id": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA#4",
+    ///                     "type": "RevocationList2020Status",
+    ///                     "revocationListIndex": "4",
+    ///                     "revocationListCredential": "did:evan:EiA0Ns-jiPwu2Pl4GQZpkTKBjvFeRXxwGgXRTfG1Lyi8aA"
+    ///                 },
+    ///                 "credentialSubject": {
+    ///                     "id": "did:evan:EiAee4ixDnSP0eWyp0YFV7Wt9yrZ3w841FNuv9NSLFSCVA",
+    ///                     "data": {
+    ///                         "bio": "biography"
+    ///                     }
+    ///                 }
+    ///             }"###;
+    ///
+    ///             // convert the credential to nquads
+    ///             vade_evan
+    ///                 .helper_convert_credential_to_nquads(credential)
+    ///                 .await?;
+    ///
+    ///             Ok(())
+    ///         }
+    ///     } else {
+    ///         // currently no example for target-c-sdk and c-lib/target-java-lib
+    ///     }
+    /// }
+    #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+    pub async fn helper_convert_credential_to_nquads(
+        &mut self,
+        credential: &str,
+    ) -> Result<String, VadeEvanError> {
+        let credential_helper = Credential::new(self)?;
+        credential_helper
+            .convert_credential_to_nquads(credential)
+            .await
+            .map_err(|err| err.into())
+    }
+
     /// Proposes to share a proof for a credential.
     /// The proof proposal consists of the fields the prover wants to reveal per schema.
     ///

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -496,7 +496,7 @@ impl VadeEvan {
             .map_err(|err| err.into())
     }
 
-    /// Converts a given credential to nquads Vector
+    /// Converts a Credential to canonized nquads
     ///
     /// # Arguments
     ///
@@ -562,7 +562,7 @@ impl VadeEvan {
     ///         // currently no example for target-c-sdk and c-lib/target-java-lib
     ///     }
     /// }
-    #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+    #[cfg(all(feature = "vc-zkp-bbs"))]
     pub async fn helper_convert_credential_to_nquads(
         &mut self,
         credential: &str,

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -792,7 +792,7 @@ pub extern "C" fn execute_vade(
                     .map_err(stringify_vade_evan_error)
             }
         }),
-        #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+        #[cfg(all(feature = "vc-zkp-bbs"))]
         "helper_convert_credential_to_nquads" => runtime.block_on({
             async {
                 let mut vade_evan = get_vade_evan(

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -770,6 +770,26 @@ pub extern "C" fn execute_vade(
                     .map_err(stringify_vade_evan_error)
             }
         }),
+        #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+        "helper_convert_credential_to_nquads" => runtime.block_on({
+            async {
+                let mut vade_evan = get_vade_evan(
+                    Some(&str_config),
+                    #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
+                    ptr_request_list,
+                    #[cfg(all(feature = "c-lib", feature = "target-c-sdk"))]
+                    request_function_callback,
+                )
+                .map_err(stringify_generic_error)?;
+                vade_evan
+                    .helper_convert_credential_to_nquads(
+                        arguments_vec.get(0).unwrap_or_else(|| &no_args),
+                    )
+                    .await
+                    .map_err(stringify_vade_evan_error)?;
+                Ok("".to_string())
+            }
+        }),
         #[cfg(any(feature = "vc-zkp-bbs"))]
         "run_custom_function" => runtime.block_on({
             execute_vade_function!(

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -488,13 +488,13 @@ impl<'a> Credential<'a> {
         }
     }
 
-    /// Converts a Credential to nquads
+    /// Converts a Credential to canonized nquads
     ///
     /// # Arguments
     /// * `credential_str` - Credential to be converted
     ///
     /// # Returns
-    /// * `nquads` - Vec of nquads
+    /// * `nquads` - Vec of canonized nquads
     pub async fn convert_credential_to_nquads(
         &self,
         credential_str: &str,

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,7 +253,7 @@ async fn main() -> Result<()> {
                     )
                     .await?
             }
-            #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+            #[cfg(all(feature = "vc-zkp-bbs"))]
             ("convert_credential_to_nquads", Some(sub_m)) => {
                 get_vade_evan(sub_m)?
                     .helper_convert_credential_to_nquads(get_argument_value(
@@ -434,7 +434,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
     }
 
     cfg_if::cfg_if! {
-        if #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))] {
+        if #[cfg(all(feature = "vc-zkp-bbs"))] {
             subcommand = subcommand.subcommand(
                 SubCommand::with_name("convert_credential_to_nquads")
                     .about("Converts a given credential to nquads vector.")

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,6 +253,17 @@ async fn main() -> Result<()> {
                     .await?
             }
             #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+            ("convert_credential_to_nquads", Some(sub_m)) => {
+                get_vade_evan(sub_m)?
+                    .helper_convert_credential_to_nquads(get_argument_value(
+                        sub_m,
+                        "credential",
+                        None,
+                    ))
+                    .await?;
+                "".to_string()
+            }
+            #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
             ("create_self_issued_credential", Some(sub_m)) => {
                 get_vade_evan(sub_m)?
                     .helper_create_self_issued_credential(
@@ -417,6 +428,16 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .about("Verifies a given credential by checking if given master secret was incorporated into proof and if proof was signed with issuers public key.")
                     .arg(get_clap_argument("credential")?)
                     .arg(get_clap_argument("master_secret")?)
+            );
+        } else {}
+    }
+
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))] {
+            subcommand = subcommand.subcommand(
+                SubCommand::with_name("convert_credential_to_nquads")
+                    .about("Converts a given credential to nquads vector.")
+                    .arg(get_clap_argument("credential")?)
             );
         } else {}
     }

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -815,7 +815,7 @@ pub async fn execute_vade(
             let payload_result = parse::<HelperConvertCredentialToNquads>(&payload);
             match payload_result {
                 Ok(payload) => {
-                    helper_convert_credential_to_nquads(payload.credential).await
+                    helper_convert_credential_to_nquads(payload.credential_str).await
                 }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -447,7 +447,7 @@ cfg_if::cfg_if! {
                 .map_err(jsify_vade_evan_error)?)
         }
 
-        #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+        #[cfg(all(feature = "vc-zkp-bbs"))]
         #[wasm_bindgen]
         pub async fn helper_convert_credential_to_nquads(
             credential: String,
@@ -810,7 +810,7 @@ pub async fn execute_vade(
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
-        #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+        #[cfg(all(feature = "vc-zkp-bbs"))]
         "helper_convert_credential_to_nquads" => {
             let payload_result = parse::<HelperConvertCredentialToNquads>(&payload);
             match payload_result {

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -189,6 +189,12 @@ struct HelperVerifyPresentationPayload {
     pub presentation_str: String,
     pub proof_request_str: String,
 }
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HelperConvertCredentialToNquads {
+    pub credential_str: String,
+}
+
 
 #[wasm_bindgen]
 pub fn set_panic_hook() {
@@ -436,6 +442,20 @@ cfg_if::cfg_if! {
                     &subject_did,
                 ).await
                 .map_err(jsify_vade_evan_error)?)
+        }
+
+        #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+        #[wasm_bindgen]
+        pub async fn helper_convert_credential_to_nquads(
+            credential: String,
+        ) -> Result<String, JsValue> {
+            let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
+            vade_evan
+                .helper_convert_credential_to_nquads(
+                    &credential,
+                ).await
+                .map_err(jsify_vade_evan_error)?;
+            Ok("".to_string())
         }
 
         #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
@@ -782,6 +802,16 @@ pub async fn execute_vade(
                         payload.subject_did,
                     )
                     .await
+                }
+                Err(error) => Err(get_parsing_error_message(&error, &payload)),
+            }
+        }
+        #[cfg(all(feature = "vc-zkp-bbs", feature = "did-sidetree"))]
+        "helper_convert_credential_to_nquads" => {
+            let payload_result = parse::<HelperConvertCredentialToNquads>(&payload);
+            match payload_result {
+                Ok(payload) => {
+                    helper_convert_credential_to_nquads(payload.credential).await
                 }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }


### PR DESCRIPTION
## Description

This MR adds `helper_convert_credential_to_nquads` helper function to Credentials helper to provide support for nquads conversion to sdk functions

## Details

- Add `helper_convert_credential_to_nquads`
- Update bindings for c, wasm and cli
- Add test case for `helper_convert_credential_to_nquads`
- Update Versions.md
