### PR TITLE
Remove unsused credential values from helper_create_credential_request

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -16,6 +16,7 @@
 ### Fixes
 
 - fix revealed properties in `CredentialSubject`'s data in `create_presentation` helper
+- remove unsued `credential_values` param from `helper_create_credential_request`
 
 ### Deprecation
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -12,6 +12,7 @@
     - `issuer_public_key_did`
     - `issuer_proving_key`
 - add `helper_convert_credential_to_nquads` helper function
+- add optional param `credential_values` to `helper_create_credential_offer` helper function
 
 ### Fixes
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -349,7 +349,6 @@ impl VadeEvan {
     ///
     /// * `issuer_public_key` - issuer public key
     /// * `bbs_secret` - master secret of the holder/receiver
-    /// * `credential_values` - JSON string with cleartext values to be signed in the credential
     /// * `credential_offer` - JSON string with credential offer by issuer
     /// * `credential_schema_did` - did for credential schema
     ///
@@ -370,16 +369,12 @@ impl VadeEvan {
     ///                "credentialMessageCount": 2
     ///            }"#;
     ///            let bbs_secret = r#"OASkVMA8q6b3qJuabvgaN9K1mKoqptCv4SCNvRmnWuI="#;
-    ///            let credential_values = r#"{
-    ///                "email": "value@x.com"
-    ///            }"#;
     ///            let issuer_pub_key = r#"jCv7l26izalfcsFe6j/IqtVlDolo2Y3lNld7xOG63GjSNHBVWrvZQe2O859q9JeVEV4yXtfYofGQSWrMVfgH5ySbuHpQj4fSgLu4xXyFgMidUO1sIe0NHRcXpOorP01o"#;
     ///
     ///            let credential_request = vade_evan
     ///                .helper_create_credential_request(
     ///                    issuer_pub_key,
     ///                    bbs_secret,
-    ///                    credential_values,
     ///                    credential_offer,
     ///                    "did:evan:EiACv4q04NPkNRXQzQHOEMa3r1p_uINgX75VYP2gaK5ADw",
     ///                )
@@ -397,7 +392,6 @@ impl VadeEvan {
         &mut self,
         issuer_public_key: &str,
         bbs_secret: &str,
-        credential_values: &str,
         credential_offer: &str,
         credential_schema_did: &str,
     ) -> Result<String, VadeEvanError> {
@@ -406,7 +400,6 @@ impl VadeEvan {
             .create_credential_request(
                 issuer_public_key,
                 bbs_secret,
-                credential_values,
                 credential_offer,
                 credential_schema_did,
             )

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -288,6 +288,7 @@ impl VadeEvan {
     /// * `issuer_did` - DID of issuer
     /// * `is_credential_status_included` - true if credentialStatus is included in credential
     /// * `required_reveal_statements` - required_revealed_statements indices array in serialized form
+    /// * `credential_values` - optional key value pairs for credential subject data values
     ///
     /// # Returns
     /// * credential offer as JSON serialized [`BbsCredentialOffer`](https://docs.rs/vade_evan_bbs/*/vade_evan_bbs/struct.BbsCredentialOffer.html)
@@ -311,6 +312,7 @@ impl VadeEvan {
     ///                     ISSUER_DID,
     ///                     true,
     ///                     "[1]",
+    ///                     None,
     ///                 )
     ///                 .await?;
     ///
@@ -329,6 +331,7 @@ impl VadeEvan {
         issuer_did: &str,
         is_credential_status_included: bool,
         required_reveal_statements: &str,
+        credential_values: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         let mut credential = Credential::new(self)?;
         credential
@@ -338,6 +341,7 @@ impl VadeEvan {
                 issuer_did,
                 is_credential_status_included,
                 required_reveal_statements,
+                credential_values,
             )
             .await
             .map_err(|err| err.into())

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -562,6 +562,7 @@ pub extern "C" fn execute_vade(
                         arguments_vec.get(2).unwrap_or_else(|| &no_args),
                         is_credential_status_included,
                         arguments_vec.get(4).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(5).map(|x| &**x),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -584,7 +584,6 @@ pub extern "C" fn execute_vade(
                         arguments_vec.get(1).unwrap_or_else(|| &no_args),
                         arguments_vec.get(2).unwrap_or_else(|| &no_args),
                         arguments_vec.get(3).unwrap_or_else(|| &no_args),
-                        arguments_vec.get(4).unwrap_or_else(|| &no_args),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)

--- a/src/helpers/credential.rs
+++ b/src/helpers/credential.rs
@@ -189,7 +189,6 @@ impl<'a> Credential<'a> {
         &mut self,
         issuer_public_key: &str,
         bbs_secret: &str,
-        credential_values: &str,
         credential_offer: &str,
         credential_schema_did: &str,
     ) -> Result<String, CredentialError> {
@@ -201,13 +200,11 @@ impl<'a> Credential<'a> {
             r#"{{
                 "credentialOffer": {},
                 "masterSecret": "{}",
-                "credentialValues": {},
                 "issuerPubKey": "{}",
                 "credentialSchema": {}
             }}"#,
             credential_offer,
             bbs_secret,
-            credential_values,
             issuer_public_key,
             serde_json::to_string(&credential_schema)?
         );
@@ -715,16 +712,13 @@ mod tests {
             .await?;
 
         let bbs_secret = r#"OASkVMA8q6b3qJuabvgaN9K1mKoqptCv4SCNvRmnWuI="#;
-        let credential_values = r#"{
-        "email": "value@x.com"
-    }"#;
+
         let issuer_pub_key = r#"jCv7l26izalfcsFe6j/IqtVlDolo2Y3lNld7xOG63GjSNHBVWrvZQe2O859q9JeVEV4yXtfYofGQSWrMVfgH5ySbuHpQj4fSgLu4xXyFgMidUO1sIe0NHRcXpOorP01o"#;
 
         let credential_request = vade_evan
             .helper_create_credential_request(
                 issuer_pub_key,
                 bbs_secret,
-                credential_values,
                 &credential_offer,
                 SCHEMA_DID,
             )

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,7 @@ async fn main() -> Result<()> {
                         get_argument_value(sub_m, "issuer_did", None),
                         include_credential_status,
                         get_argument_value(sub_m, "required_reveal_statements", None),
+                        get_optional_argument_value(sub_m, "credential_values"),
                     )
                     .await?
             }
@@ -370,6 +371,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .arg(get_clap_argument("issuer_did")?)
                     .arg(get_clap_argument("include_credential_status")?)
                     .arg(get_clap_argument("required_reveal_statements")?)
+                    .arg(get_clap_argument("credential_values")?)
             );
         } else {}
     }
@@ -940,7 +942,7 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
         "credential_values" => Arg::with_name("credential_values")
             .long("credential_values")
             .value_name("credential_values")
-            .required(true)
+            .required(false)
             .help("JSON string with cleartext values to be signed in the credential")
             .takes_value(true),
         "bbs_secret" => Arg::with_name("bbs_secret")

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,7 +203,6 @@ async fn main() -> Result<()> {
                     .helper_create_credential_request(
                         get_argument_value(sub_m, "issuer_public_key", None),
                         get_argument_value(sub_m, "bbs_secret", None),
-                        get_argument_value(sub_m, "credential_values", None),
                         get_argument_value(sub_m, "credential_offer", None),
                         get_argument_value(sub_m, "schema_did", None),
                     )
@@ -382,7 +381,6 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .about("Requests a credential. This message is the response to a credential offering and is sent by the potential credential holder. It incorporates the target schema, credential definition offered by the issuer, and the encoded values the holder wants to get signed. The credential is not stored on-chain and needs to be kept private.")
                     .arg(get_clap_argument("issuer_public_key")?)
                     .arg(get_clap_argument("bbs_secret")?)
-                    .arg(get_clap_argument("credential_values")?)
                     .arg(get_clap_argument("credential_offer")?)
                     .arg(get_clap_argument("schema_did")?)
                     .arg(get_clap_argument("target")?)

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -110,6 +110,7 @@ struct HelperCreateCredentialOfferPayload {
     pub subject_did: Option<String>,
     pub is_credential_status_included: bool,
     pub required_reveal_statements: String,
+    pub credential_values: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -343,6 +344,7 @@ cfg_if::cfg_if! {
             issuer_did: String,
             is_credential_status_included: bool,
             required_reveal_statements: String,
+            credential_values: Option<String>,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
             let offer = vade_evan
@@ -352,6 +354,7 @@ cfg_if::cfg_if! {
                     &issuer_did,
                     is_credential_status_included,
                     &required_reveal_statements,
+                    credential_values.as_ref().map(|x| x.as_ref())
                 ).await
                 .map_err(jsify_vade_evan_error)?;
             Ok(offer)
@@ -742,6 +745,7 @@ pub async fn execute_vade(
                         payload.issuer_did,
                         payload.is_credential_status_included,
                         payload.required_reveal_statements,
+                        payload.credential_values,
                     )
                     .await
                 }

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -117,7 +117,6 @@ struct HelperCreateCredentialOfferPayload {
 struct HelperCreateCredentialRequestPayload {
     pub issuer_public_key: String,
     pub bbs_secret: String,
-    pub credential_values: String,
     pub credential_offer: String,
     pub credential_schema: String,
 }
@@ -363,7 +362,6 @@ cfg_if::cfg_if! {
         pub async fn helper_create_credential_request(
             issuer_public_key: String,
             bbs_secret: String,
-            credential_values: String,
             credential_offer: String,
             credential_schema: String
         ) -> Result<String, JsValue> {
@@ -372,7 +370,6 @@ cfg_if::cfg_if! {
                 .helper_create_credential_request(
                     &issuer_public_key,
                     &bbs_secret,
-                    &credential_values,
                     &credential_offer,
                     &credential_schema).await
                     .map_err(jsify_vade_evan_error)?;
@@ -759,7 +756,6 @@ pub async fn execute_vade(
                     helper_create_credential_request(
                         payload.issuer_public_key,
                         payload.bbs_secret,
-                        payload.credential_values,
                         payload.credential_offer,
                         payload.credential_schema,
                     )


### PR DESCRIPTION
## Description

The param credential values is unused and the values are included in `credential_offer` now 

## Detais

- remove unused param
- update bindings
- update test
- update versions.md