### PR TITLE
Add optional credential values in create credential offer helper

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -12,6 +12,7 @@
     - `issuer_public_key_did`
     - `issuer_proving_key`
 - add `helper_convert_credential_to_nquads` helper function
+- add optional param `credential_values` to `helper_create_credential_offer` helper function
 
 ### Fixes
 

--- a/src/api/vade_evan_api.rs
+++ b/src/api/vade_evan_api.rs
@@ -288,6 +288,7 @@ impl VadeEvan {
     /// * `issuer_did` - DID of issuer
     /// * `is_credential_status_included` - true if credentialStatus is included in credential
     /// * `required_reveal_statements` - required_revealed_statements indices array in serialized form
+    /// * `credential_values` - optional key value pairs for credential subject data values
     ///
     /// # Returns
     /// * credential offer as JSON serialized [`BbsCredentialOffer`](https://docs.rs/vade_evan_bbs/*/vade_evan_bbs/struct.BbsCredentialOffer.html)
@@ -311,6 +312,7 @@ impl VadeEvan {
     ///                     ISSUER_DID,
     ///                     true,
     ///                     "[1]",
+    ///                     None,
     ///                 )
     ///                 .await?;
     ///
@@ -329,6 +331,7 @@ impl VadeEvan {
         issuer_did: &str,
         is_credential_status_included: bool,
         required_reveal_statements: &str,
+        credential_values: Option<&str>,
     ) -> Result<String, VadeEvanError> {
         let mut credential = Credential::new(self)?;
         credential
@@ -338,6 +341,7 @@ impl VadeEvan {
                 issuer_did,
                 is_credential_status_included,
                 required_reveal_statements,
+                credential_values,
             )
             .await
             .map_err(|err| err.into())

--- a/src/c_lib.rs
+++ b/src/c_lib.rs
@@ -562,6 +562,7 @@ pub extern "C" fn execute_vade(
                         arguments_vec.get(2).unwrap_or_else(|| &no_args),
                         is_credential_status_included,
                         arguments_vec.get(4).unwrap_or_else(|| &no_args),
+                        arguments_vec.get(5).map(|x| &**x),
                     )
                     .await
                     .map_err(stringify_vade_evan_error)

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,7 @@ async fn main() -> Result<()> {
                         get_argument_value(sub_m, "issuer_did", None),
                         include_credential_status,
                         get_argument_value(sub_m, "required_reveal_statements", None),
+                        get_optional_argument_value(sub_m, "credential_values"),
                     )
                     .await?
             }
@@ -370,6 +371,7 @@ fn add_subcommand_helper<'a>(app: App<'a, 'a>) -> Result<App<'a, 'a>> {
                     .arg(get_clap_argument("issuer_did")?)
                     .arg(get_clap_argument("include_credential_status")?)
                     .arg(get_clap_argument("required_reveal_statements")?)
+                    .arg(get_clap_argument("credential_values")?)
             );
         } else {}
     }
@@ -940,7 +942,7 @@ fn get_clap_argument(arg_name: &str) -> Result<Arg> {
         "credential_values" => Arg::with_name("credential_values")
             .long("credential_values")
             .value_name("credential_values")
-            .required(true)
+            .required(false)
             .help("JSON string with cleartext values to be signed in the credential")
             .takes_value(true),
         "bbs_secret" => Arg::with_name("bbs_secret")

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -110,6 +110,7 @@ struct HelperCreateCredentialOfferPayload {
     pub subject_did: Option<String>,
     pub is_credential_status_included: bool,
     pub required_reveal_statements: String,
+    pub credential_values: Option<String>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -343,6 +344,7 @@ cfg_if::cfg_if! {
             issuer_did: String,
             is_credential_status_included: bool,
             required_reveal_statements: String,
+            credential_values: Option<String>,
         ) -> Result<String, JsValue> {
             let mut vade_evan = get_vade_evan(None).map_err(jsify_generic_error)?;
             let offer = vade_evan
@@ -352,6 +354,7 @@ cfg_if::cfg_if! {
                     &issuer_did,
                     is_credential_status_included,
                     &required_reveal_statements,
+                    credential_values.as_ref().map(|x| x.as_ref())
                 ).await
                 .map_err(jsify_vade_evan_error)?;
             Ok(offer)
@@ -742,6 +745,7 @@ pub async fn execute_vade(
                         payload.issuer_did,
                         payload.is_credential_status_included,
                         payload.required_reveal_statements,
+                        payload.credential_values,
                     )
                     .await
                 }


### PR DESCRIPTION
## Merge Dependencies

#88

## Description

Add optional credential_values param to helper_create_credential_offer function, currently the helper function create only empty offers, this will add ability to create offer with values .

## Details

- Add `credential_values` param to `helper_create_credential_values`
- Add test cases
- Update bindings
- Update versions.md