### PR TITLE
Pass signer_address in verify presentation as optional param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.4.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=experimental/develop-next#7ec152939fd3d106b171a8ad58c26f35c8a5c776"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/make-signer-address-optional#7de1fbabbd0d55e11381dddf029dced062b517c9"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4912,7 +4912,7 @@ dependencies = [
 [[package]]
 name = "vade-evan-bbs"
 version = "0.4.0"
-source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=feature/make-signer-address-optional#7de1fbabbd0d55e11381dddf029dced062b517c9"
+source = "git+https://github.com/evannetwork/vade-evan-bbs.git?branch=experimental/develop-next#57f05fce63534bef6e1aab3cb7e698fb6d0ea3ac"
 dependencies = [
  "async-trait",
  "base64 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ optional = true
 
 [dependencies.vade-evan-bbs]
 git = "https://github.com/evannetwork/vade-evan-bbs.git"
-branch = "feature/make-signer-address-optional"
+branch = "experimental/develop-next"
 optional = true
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,7 +147,7 @@ optional = true
 
 [dependencies.vade-evan-bbs]
 git = "https://github.com/evannetwork/vade-evan-bbs.git"
-branch = "experimental/develop-next"
+branch = "feature/make-signer-address-optional"
 optional = true
 default-features = false
 

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -13,6 +13,7 @@
     - `issuer_proving_key`
 - add `helper_convert_credential_to_nquads` helper function
 - add optional param `credential_values` to `helper_create_credential_offer` helper function
+- update `helper_verify_presentation` for optional `signer_address`
 
 ### Fixes
 

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -196,7 +196,6 @@ struct HelperConvertCredentialToNquads {
     pub credential_str: String,
 }
 
-
 #[wasm_bindgen]
 pub fn set_panic_hook() {
     console_error_panic_hook::set_once();
@@ -814,9 +813,7 @@ pub async fn execute_vade(
         "helper_convert_credential_to_nquads" => {
             let payload_result = parse::<HelperConvertCredentialToNquads>(&payload);
             match payload_result {
-                Ok(payload) => {
-                    helper_convert_credential_to_nquads(payload.credential_str).await
-                }
+                Ok(payload) => helper_convert_credential_to_nquads(payload.credential_str).await,
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -824,8 +821,10 @@ pub async fn execute_vade(
         "helper_create_proof_proposal" => {
             let payload_result = parse::<HelperCreateProofProposalPayload>(&payload);
             match payload_result {
-                Ok(payload) =>
-                    helper_create_proof_proposal(payload.schema_did, payload.revealed_attributes).await,
+                Ok(payload) => {
+                    helper_create_proof_proposal(payload.schema_did, payload.revealed_attributes)
+                        .await
+                }
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }
@@ -833,16 +832,23 @@ pub async fn execute_vade(
         "helper_create_proof_request" => {
             let payload_result = parse::<HelperCreateProofRequestPayload>(&payload);
             match payload_result {
-                Ok(parsed_value) =>
-                    match parsed_value {
-                        HelperCreateProofRequestPayload::FromScratch(from_scratch) =>
-                            helper_create_proof_request(from_scratch.schema_did, from_scratch.revealed_attributes).await,
-                        HelperCreateProofRequestPayload::FromProposal(proposal) =>
-                            match serde_json::to_string(&proposal) {
-                                Ok(stringified) => helper_create_proof_request_from_proposal(&stringified).await,
-                                Err(error) => Err(get_parsing_error_message(&error, &payload)),
-                            },
-                    },
+                Ok(parsed_value) => match parsed_value {
+                    HelperCreateProofRequestPayload::FromScratch(from_scratch) => {
+                        helper_create_proof_request(
+                            from_scratch.schema_did,
+                            from_scratch.revealed_attributes,
+                        )
+                        .await
+                    }
+                    HelperCreateProofRequestPayload::FromProposal(proposal) => {
+                        match serde_json::to_string(&proposal) {
+                            Ok(stringified) => {
+                                helper_create_proof_request_from_proposal(&stringified).await
+                            }
+                            Err(error) => Err(get_parsing_error_message(&error, &payload)),
+                        }
+                    }
+                },
                 Err(error) => Err(get_parsing_error_message(&error, &payload)),
             }
         }


### PR DESCRIPTION
## Description

The `signer_address` property in `VerifyProofPayload` struct is optional so we need to update `helper_verify_presentation` function in Presentation helper to pass it only if we have proof property present in our `Presentation`

## Details

- Update `helper_verify_presenation` to pass `signer_address` to `vade-evan-bbs` optionally 